### PR TITLE
 team.appInsights.enabled default value should be bool

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       "properties": {
         "team.appInsights.enabled": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "description": "Enables Application Insights telemetry collection for the Team Services extension."
         },
         "team.logging.level": {


### PR DESCRIPTION
fixed "team.appInsights.enabled" given default string value instead of Boolean. Throws warning in vscode.