### PR TITLE
Check for accounts ending with ".visualstudio.com" in accessTokens

### DIFF
--- a/src/helpers/settings.ts
+++ b/src/helpers/settings.ts
@@ -42,7 +42,8 @@ export class Settings {
             let global: string = undefined;
             for (var index = 0; index < tokens.length; index++) {
                 let element: any = tokens[index];
-                if (element.account === account) {
+                if (element.account === account ||
+                    element.account === account + ".visualstudio.com") {
                     return element.token;
                 } else if (element.account === "global") {
                     global = element.token;


### PR DESCRIPTION
Received feedback that some folks were putting their entire host name in the accessTokens setting.  Easy enough to support.