### PR TITLE
Adding additional telemetry for WIT

### DIFF
--- a/src/clients/witclient.ts
+++ b/src/clients/witclient.ts
@@ -77,8 +77,10 @@ export class WitClient extends BaseClient {
                             if (workItem) {
                                 let url: string = undefined;
                                 if (workItem.id === undefined) {
+                                    self.ReportEvent(TelemetryEvents.OpenAdditionalQueryResults);
                                     url = WorkItemTrackingService.GetMyQueryResultsUrl(self._serverContext.TeamProjectUrl, query.label);
                                 } else {
+                                    self.ReportEvent(TelemetryEvents.ViewWorkItem);
                                     url = WorkItemTrackingService.GetEditWorkItemUrl(self._serverContext.TeamProjectUrl, workItem.id);
                                 }
                                 Logger.LogInfo("Work Item Url: " + url);
@@ -108,8 +110,10 @@ export class WitClient extends BaseClient {
                 if (workItem) {
                     let url: string = undefined;
                     if (workItem.id === undefined) {
+                        self.ReportEvent(TelemetryEvents.OpenAdditionalQueryResults);
                         url = WorkItemTrackingService.GetWorkItemsBaseUrl(self._serverContext.TeamProjectUrl);
                     } else {
+                        self.ReportEvent(TelemetryEvents.ViewWorkItem);
                         url = WorkItemTrackingService.GetEditWorkItemUrl(self._serverContext.TeamProjectUrl, workItem.id);
                     }
                     Logger.LogInfo("Work Item Url: " + url);

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -41,6 +41,7 @@ export class SettingNames {
 
 export class TelemetryEvents {
     static TelemetryPrefix: string = Constants.ExtensionName + "/";
+    static OpenAdditionalQueryResults: string = TelemetryEvents.TelemetryPrefix + "openaddlqueryresults";
     static OpenBlamePage: string = TelemetryEvents.TelemetryPrefix + "openblame";
     static OpenBuildSummaryPage: string = TelemetryEvents.TelemetryPrefix + "openbuildsummary";
     static OpenFileHistory: string = TelemetryEvents.TelemetryPrefix + "openfilehistory";


### PR DESCRIPTION
The extension wasn't sending telemetry for ViewWorkItem.  Also, adding telemetry for when users choose to view the additional query results (e.g., > 200 results).