### PR TITLE
Limiting keywords to five (latest vsce requirement)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "Git",
     "Team Services",
     "Visual Studio Online",
-    "Visual Studio Team Services",
-    "VSO",
-    "VSTS"
+    "Visual Studio Team Services"
   ],
   "categories": [
     "Other"


### PR DESCRIPTION
Latest version of vsce (packaging) tool limits the number of keywords to five (it prompts you at command line to accept the first five).  Without this change, "gulp package" hangs.