### PR TITLE
Show 'No Git repo' message when appropriate

### DIFF
--- a/src/team-extension.ts
+++ b/src/team-extension.ts
@@ -118,7 +118,7 @@ export class TeamExtension  {
                 });
             }
         } else {
-            VsCodeUtils.ShowErrorMessage(this._errorMessage);
+            VsCodeUtils.ShowErrorMessage(Strings.NoGitRepoInformation);
         }
     }
 
@@ -134,7 +134,7 @@ export class TeamExtension  {
                 VsCodeUtils.ShowErrorMessage(msg);
             });
         } else {
-            VsCodeUtils.ShowErrorMessage(this._errorMessage);
+            VsCodeUtils.ShowErrorMessage(Strings.NoGitRepoInformation);
         }
     }
 


### PR DESCRIPTION
For login and logout commands, ensure we provide the proper error message when they're run after a non-Team Services or non-TFS git repo folder is opened.

Thanks to @olivierdagenais for finding this bug!