### PR TITLE
Improve Team Services login experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@ later.  Then, in the Visual Studio Code Command Palette (`F1`) select `Install E
 `Visual Studio Team Services` by Microsoft.
 
 ### Team Services
-If you are connecting to Team Services, the latest version of the extension will prompt for your personal
-access token (PAT) and store it securely.  Previously, you needed to create a token and store it in your
+If you are connecting to Team Services, you will need a personal access token (PAT) to securely access your account.  The latest
+version of the extension will prompt for your token and store it securely.  Previously, you needed to store your token in your
 Visual Studio Code user settings.
 
 If you do not have a personal access token yet, you will need to create one on your Team Services account.
-To create the token, go [here](https://www.visualstudio.com/en-us/get-started/setup/use-personal-access-tokens-to-authenticate)
-to learn how.
+To learn more about access tokens and to create your own, go [here](https://www.visualstudio.com/en-us/get-started/setup/use-personal-access-tokens-to-authenticate) to learn how.
 * When you create your token, create it with the **Build (read)**, **Code (read)** and **Work items (read)** scopes to ensure full functionality.
 * You can also use *All Scopes*, but the minimum required scopes are those listed above.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "team",
   "displayName": "Visual Studio Team Services",
-  "description": "Monitor your builds and manage your pull requests and work items for your Team Services Git repositories",
+  "description": "Connect to Team Services, monitor your builds and manage your pull requests and work items for your Git repositories",
   "version": "1.103.0",
   "publisher": "ms-vsts",
   "icon": "assets/team.png",

--- a/src/clients/feedbackclient.ts
+++ b/src/clients/feedbackclient.ts
@@ -18,6 +18,12 @@ export class FeedbackClient extends BaseClient {
         super(telemetryService);
     }
 
+    //This event *will* honor whether Application Insights is enabled or not.
+    public SendEvent(telemetryId: string): void {
+        this.ReportEvent(telemetryId, undefined);
+    }
+
+    //This feedback will go no matter whether Application Insights is enabled or not.
     public SendFeedback(): void {
         let self = this;
 

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -8,6 +8,7 @@
 export class Constants {
     static ExtensionName: string = "team";
     static OAuth: string = "OAuth";
+    static TokenLearnMoreUrl: string = "https://aka.ms/v9r4jt";
 }
 
 export class CommandNames {
@@ -61,6 +62,7 @@ export class TelemetryEvents {
     static SendASmile: string = TelemetryEvents.TelemetryPrefix + "sendasmile";
     static ShowMyWorkItemQueries: string = TelemetryEvents.TelemetryPrefix + "showmyworkitemqueries";
     static StartUp: string = TelemetryEvents.TelemetryPrefix + "startup";
+    static TokenLearnMoreClick: string = TelemetryEvents.TelemetryPrefix + "tokenlearnmoreclick";
     static ViewPullRequest: string = TelemetryEvents.TelemetryPrefix + "viewpullrequest";
     static ViewPullRequests: string = TelemetryEvents.TelemetryPrefix + "viewpullrequests";
     static ViewMyWorkItems: string = TelemetryEvents.TelemetryPrefix + "viewmyworkitems";

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -14,7 +14,7 @@ export class Strings {
     static NavigateToBuildSummary: string = "Click to view build";
     static NavigateToTeamServicesWebSite: string = "Click to view your team project website.";
     static NoAccessTokenFound: string = "A personal access token for this Team Services repository was not found in your local user settings.";
-    static NoAccessTokenLearnMoreRunLogin: string = "You are not connected to Team Services. Please learn more and then run the 'team login' command.";
+    static NoAccessTokenLearnMoreRunLogin: string = "You are not connected to Team Services. Select 'Learn more...' and then run the 'team login' command.";
     static NoAccessTokenRunLogin: string = "You are not connected to Team Services. Please run the 'team login' command.";
     static NoTeamServerCredentialsRunLogin: string = "You are not connected to a Team Foundation Server.  Please run the 'team login' command.";
     static NoBuildsFound: string = "No builds were found for this repository and branch. Click to view your team project's build definitions page.";

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -14,8 +14,9 @@ export class Strings {
     static NavigateToBuildSummary: string = "Click to view build";
     static NavigateToTeamServicesWebSite: string = "Click to view your team project website.";
     static NoAccessTokenFound: string = "A personal access token for this Team Services repository was not found in your local user settings.";
-    static NoAccessTokenRunLogin: string = "No personal access token was found for Team Services.  Please run the 'team login' command.";
-    static NoTeamServerCredentialsRunLogin: string = "No credentials were found for Team Foundation Server.  Please run the 'team login' command.";
+    static NoAccessTokenLearnMoreRunLogin: string = "You are not connected to Team Services. Please learn more and then run the 'team login' command.";
+    static NoAccessTokenRunLogin: string = "You are not connected to Team Services. Please run the 'team login' command.";
+    static NoTeamServerCredentialsRunLogin: string = "You are not connected to a Team Foundation Server.  Please run the 'team login' command.";
     static NoBuildsFound: string = "No builds were found for this repository and branch. Click to view your team project's build definitions page.";
     static NoGitRepoInformation: string = "No Team Services or Team Foundation Server Git repository configuration was found.  Ensure you've opened a folder that contains a Git repository.";
     static NoSourceFileForBlame: string = "A source file must be opened to show blame information.";
@@ -27,6 +28,7 @@ export class Strings {
     static SendFeedbackPrompt: string = "Enter your feedback here (1000 char limit)";
     static NoFeedbackSent: string = "No feedback was sent.";
     static ThanksForFeedback: string = "Thanks for sending feedback!";
+    static TokenLearnMore: string = "Learn more...";
 
     static ChoosePullRequest: string = "Choose a pull request";
     static ChooseWorkItem: string = "Choose a work item";

--- a/src/helpers/vscodeutils.ts
+++ b/src/helpers/vscodeutils.ts
@@ -4,8 +4,10 @@
 *--------------------------------------------------------------------------------------------*/
 "use strict";
 
-import { QuickPickItem, Range, window } from "vscode";
+import { MessageItem, QuickPickItem, Range, window } from "vscode";
 import { Constants } from "./constants";
+
+import Q = require("q");
 
 export class BaseQuickPickItem implements QuickPickItem {
     label: string;
@@ -15,6 +17,12 @@ export class BaseQuickPickItem implements QuickPickItem {
 
 export class WorkItemQueryQuickPickItem extends BaseQuickPickItem {
     wiql: string;
+}
+
+export class UrlMessageItem implements MessageItem {
+    title: string;
+    url: string;
+    telemetryId: string;
 }
 
 export class VsCodeUtils {
@@ -40,6 +48,24 @@ export class VsCodeUtils {
 
     public static ShowErrorMessage(message: string) {
         window.showErrorMessage("(" + Constants.ExtensionName + ") " + message);
+    }
+
+    //Allow ability to show additional buttons with the message and return any chosen one via Promise
+    public static ShowErrorMessageWithOptions(message: string, ...urlMessageItem: UrlMessageItem[]) : Q.Promise<UrlMessageItem> {
+        let promiseToReturn: Q.Promise<UrlMessageItem>;
+        let deferred = Q.defer<UrlMessageItem>();
+        promiseToReturn = deferred.promise;
+
+        //Use the typescript spread operator to pass the rest parameter to showErrorMessage
+        window.showErrorMessage("(" + Constants.ExtensionName + ") " + message, ...urlMessageItem).then((item) => {
+            if (item) {
+                deferred.resolve(item);
+            } else {
+                deferred.resolve(undefined);
+            }
+        });
+
+        return promiseToReturn;
     }
 
     public static ShowWarningMessage(message: string) {


### PR DESCRIPTION
Add a button to the error message which is displayed when there's no PAT available for a Team Services account.  Track telemetry for the button click (opt-out supported).  Improve README description for Team Services.