### PR TITLE
Pin version of ApplicationInsights to 15.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "vscode": "^0.11.x"
   },
   "dependencies": {
-    "applicationinsights": "^0.15.11",
+    "applicationinsights": "0.15.16",
     "event-stream": "^3.3.2",
     "fs": "0.0.2",
     "git-repo-info": "^1.1.2",


### PR DESCRIPTION
v15.17 added a 34MB file to the NPM package which increased the VSIX size to 10MB (from 884KB).  See #31 