### PR TITLE
Add filewatcher to config (remote origin change)

### DIFF
--- a/src/contexts/gitcontext.ts
+++ b/src/contexts/gitcontext.ts
@@ -25,9 +25,7 @@ export class GitContext {
     private _isTeamFoundationServer: boolean = false;
 
     constructor(rootPath: string) {
-        this._isTeamServicesUrl = false;
-
-        if (rootPath != null) {
+        if (rootPath) {
             this._gitFolder = Utils.FindGitFolder(rootPath);
 
             if (this._gitFolder != null) {


### PR DESCRIPTION
#27 Fix the issue where the extension wouldn't detect a local repository after being pushed to Team Services (the extension wouldn't initialize until VS Code was restarted).


The following are a series of steps that were used to test the fix/enhancement.  Below is detailed what the expected behavior is when executed in this order.  There are other sets of steps that would provide different behavior.  Also, the behavior can change if there's no stored PAT yet (in the steps below, it is assumed that a valid PAT has already been stored for the Team Services accounts).

**from a terminal, in an empty folder, and VS Code open with the TS extension installed,**

**git init**
_This command creates the git repo without a remote.  The extension will recognize the newly created config file but it will not initialize.  If the config file were to have a valid Team Services remote, it would initialize (like if someone copied-and-pasted a config file)._


**git remote add origin git@github.com:Microsoft/Git-Credential-Manager-for-Mac-and-Linux.git**
_The extension detects the changed config file but there's no apparent effect since it isn't a TS repo._


**git remote set-url origin https://xxxxxxxxx.visualstudio.com/DefaultCollection/_git/DeepSpace**
_The extension detects the changed config file, and loads the TS info as expected._


**git remote set-url origin https://yyyyy.visualstudio.com/DefaultCollection/VSOnline/_git/Content.Java**
_The extension detects the changed config file, and loads the TS info as expected._


**git remote set-url origin https://yyyyy.visualstudio.com/VSOnline/_git/Java.VSCode.CredentialStore**
_The extension detects the changed config file, and loads the TS info as expected._


**git remote set-url origin git@github.com:Microsoft/Git-Credential-Manager-for-Mac-and-Linux.git**
_The extension detects the changed config file, and uninitializes itself so no data is shown (since it is not a TS repo)._


**git remote set-url origin https://yyyyy.visualstudio.com/VSOnline/_git/Java.VSCode.CredentialStore**
_The extension detects the changed config file, and loads the TS info as expected._


**delete the config file**
_If the file is deleted, the extension detects it, re-initializes and does not show any information._




If at any time PATs for the TS accounts aren't present, the behavior is what you would expect when no token is found (no token found message, etc.).
