### PR TITLE
Improve checking of Team Foundation Server server name formats

### DIFF
--- a/src/helpers/repoutils.ts
+++ b/src/helpers/repoutils.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+"use strict";
+
+export class RepoUtils {
+    //Checks to see if url contains /_git/ signifying a Team Foundation Git repository
+    public static IsTeamFoundationGitRepo(url: string): boolean {
+        if (url && url.toLowerCase().indexOf("/_git/") >= 0) {
+            return true;
+        }
+        return false;
+    }
+
+    //Checks to ensure it's a Team Foundation Git repo, then ensures it's hosted on visualstudio.com
+    public static IsTeamFoundationServicesRepo(url: string): boolean {
+        if (RepoUtils.IsTeamFoundationGitRepo(url) && url.toLowerCase().indexOf(".visualstudio.com") >= 0) {
+            return true;
+        }
+        return false;
+    }
+
+    //Checks to ensure it's a Team Foundation repo, then ensures it's *not* on visualstudio.com
+    public static IsTeamFoundationServerRepo(url: string): boolean {
+        if (RepoUtils.IsTeamFoundationGitRepo(url) && !RepoUtils.IsTeamFoundationServicesRepo(url)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/info/repositoryinfo.ts
+++ b/src/info/repositoryinfo.ts
@@ -5,6 +5,7 @@
 "use strict";
 
 import { Logger } from "../helpers/logger";
+import { RepoUtils } from "../helpers/repoutils";
 
 var url = require("url");
 
@@ -53,13 +54,13 @@ export class RepositoryInfo {
             this._protocol = purl.protocol;
             this._query = purl.query;
 
-            if (repositoryUrl.toLowerCase().indexOf("/_git/") >= 0) {
-                if (this._host.toLowerCase().indexOf(".visualstudio.com") >= 0) {
+            if (RepoUtils.IsTeamFoundationGitRepo(repositoryUrl)) {
+                if (RepoUtils.IsTeamFoundationServicesRepo(repositoryUrl)) {
                     let splitHost = this._host.split(".");
                     this._account = splitHost[0];
                     this._isTeamServicesUrl = true;
                     Logger.LogDebug("_isTeamServicesUrl: true");
-                } else {
+                } else if (RepoUtils.IsTeamFoundationServerRepo(repositoryUrl)) {
                     this._account = purl.host;
                     this._isTeamFoundationServer = true;
                 }

--- a/src/team-extension.ts
+++ b/src/team-extension.ts
@@ -366,6 +366,7 @@ export class TeamExtension  {
                     //Go get the details about the repository
                     let repositoryClient: QTeamServicesApi = new QTeamServicesApi(this._gitContext.RemoteUrl, [CredentialManager.GetCredentialHandler()]);
                     Logger.LogInfo("Getting repository information (vsts/info) with repositoryClient");
+                    Logger.LogDebug("RemoteUrl = " + this._gitContext.RemoteUrl);
                     repositoryClient.getVstsInfo().then((repoInfo) => {
                         Logger.LogInfo("Retrieved repository info with repositoryClient");
                         Logger.LogObject(repoInfo);
@@ -375,6 +376,7 @@ export class TeamExtension  {
                         let connectionUrl: string = (this._serverContext.RepoInfo.IsTeamServices === true ? this._serverContext.RepoInfo.AccountUrl : this._serverContext.RepoInfo.CollectionUrl);
                         let accountClient: QTeamServicesApi = new QTeamServicesApi(connectionUrl, [CredentialManager.GetCredentialHandler()]);
                         Logger.LogInfo("Getting connectionData with accountClient");
+                        Logger.LogDebug("connectionUrl = " + connectionUrl);
                         accountClient.connect().then((settings) => {
                             Logger.LogInfo("Retrieved connectionData with accountClient");
                             this.resetErrorStatus();

--- a/test/helpers/repoutils.test.ts
+++ b/test/helpers/repoutils.test.ts
@@ -1,0 +1,126 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+"use strict";
+
+import { RepoUtils }  from "../../src/helpers/repoutils";
+
+var chai = require("chai");
+/* tslint:disable:no-unused-variable */
+var expect = chai.expect;
+/* tslint:enable:no-unused-variable */
+var assert = chai.assert;
+chai.should();
+
+describe("RepoUtils", function() {
+
+    beforeEach(function() {
+        //
+    });
+
+    it("should ensure valid Team Foundation Server Git urls", function() {
+        let url : string;
+        //Server names with ports are valid
+        url = "http://pioneer-new-dt:8080/tfs/DevDiv_Projects2/_git/JavaALM";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+        url = "http://minint-i0lvs2o:8080/tfs/DefaultCollection/_git/GitProject";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+        url = "http://java-tfs2015:8081/tfs/DefaultCollection/_git/GitJava";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+        url = "http://sources2010/DefaultCollection/_git/repo";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+        url = "http://sources2010/tfs/DefaultCollection/_git/repo";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+        //Multi-part server names are valid
+        url = "http://java-tfs01.3redis.local/DefaultCollection/_git/repo";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+        url = "http://java-tfs01.loseit.local:8080/DefaultCollection/_git/repo";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+        url = "http://stdtfs.amways.local/DefaultCollection/_git/repo";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+        //IP addresses would be valid
+        url = "http://192.168.0.1/sources2010/tfs/DefaultCollection/_git/repo";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+        url = "http://192.168.0.1:8084/sources2010/tfs/DefaultCollection/_git/repo";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+        //SSH urls would be valid
+        url = "ssh://sources2010:22/tfs/DefaultCollection/_git/GitAgile";
+        assert.isTrue(RepoUtils.IsTeamFoundationServerRepo(url));
+    });
+
+    it("should ensure Team Services urls are not valid Team Foundation Server Git urls", function() {
+        let url : string;
+        url = "https://mseng.visualstudio.com/VSOnline/_git/Java.VSCode.CredentialStore";
+        assert.isFalse(RepoUtils.IsTeamFoundationServerRepo(url));
+        url = "https://mseng.visualstudio.com/DefaultCollection/VSOnline/_git/Java.IntelliJ";
+        assert.isFalse(RepoUtils.IsTeamFoundationServerRepo(url));
+        url = "ssh://mseng@mseng.visualstudio.com:22/DefaultCollection/VSOnline/_git/Java.IntelliJ/";
+        assert.isFalse(RepoUtils.IsTeamFoundationServerRepo(url));
+    });
+
+    it("should ensure valid Team Services Git urls", function() {
+        let url : string;
+        url = "https://mseng.visualstudio.com/VSOnline/_git/Java.VSCode.CredentialStore";
+        assert.isTrue(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "https://mseng.visualstudio.com/DefaultCollection/VSOnline/_git/Java.IntelliJ";
+        assert.isTrue(RepoUtils.IsTeamFoundationServicesRepo(url));
+        //SSH urls would be valid
+        url = "ssh://mseng@mseng.visualstudio.com:22/DefaultCollection/VSOnline/_git/Java.IntelliJ/";
+        assert.isTrue(RepoUtils.IsTeamFoundationServicesRepo(url));
+    });
+
+    it("should ensure Team Server urls are not valid Team Services Git urls", function() {
+        let url : string;
+
+        url = "http://pioneer-new-dt:8080/tfs/DevDiv_Projects2/_git/JavaALM";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "http://minint-i0lvs2o:8080/tfs/DefaultCollection/_git/GitProject";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "http://java-tfs2015:8081/tfs/DefaultCollection/_git/GitJava";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "http://sources2010/DefaultCollection/_git/repo";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "http://sources2010/tfs/DefaultCollection/_git/repo";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "http://java-tfs01.3redis.local/DefaultCollection/_git/repo";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "http://java-tfs01.loseit.local:8080/DefaultCollection/_git/repo";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "http://stdtfs.amways.local/DefaultCollection/_git/repo";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "http://192.168.0.1/sources2010/tfs/DefaultCollection/_git/repo";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "http://192.168.0.1:8084/sources2010/tfs/DefaultCollection/_git/repo";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "ssh://sources2010:22/tfs/DefaultCollection/_git/GitAgile";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+    });
+
+    it("should ensure valid Team Foundation Git urls", function() {
+        let url : string;
+        url = "http://sources2010/tfs/DefaultCollection/_git/repo";
+        assert.isTrue(RepoUtils.IsTeamFoundationGitRepo(url));
+        url = "https://account.visualstudio.com/DefaultCollection/VSOnline/_git/Java.IntelliJ";
+        assert.isTrue(RepoUtils.IsTeamFoundationServicesRepo(url));
+
+        //The following url has no "/_git/" in the path
+        url = "https://account.visualstudio.com/DefaultCollection/VSOnline/Java.IntelliJ";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+    });
+
+    it("should detect invalid Team Foundation Git urls", function() {
+        let url : string;
+
+        //The following urls have no "/_git/" in the path
+        url = "https://account.visualstudio.com/DefaultCollection/VSOnline/Java.IntelliJ";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "git@github.com:Microsoft/Git-Credential-Manager-for-Mac-and-Linux.git";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "https://github.com/Microsoft/vsts-vscode.git";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+        url = "https://account.visualstudio.com/DefaultCollection/VSOnline/Java.IntelliJ";
+        assert.isFalse(RepoUtils.IsTeamFoundationServicesRepo(url));
+    });
+
+});


### PR DESCRIPTION
Addresses #41 

Refactored GitContext so I could get better (some) coverage on the Team Foundation Server url validation.  The existing code wasn't checking for the proper server name formats for Team Foundation Server deployments.

Added unit tests to verify the code changes.  Also ran manual testing against Team Services, Team Foundation Server and non-Team Services repos.