### PR TITLE
Add task to upload code coverage report files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 *.vsix
 team-extension.log
 *.zip
+.taskkey

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var tslint = require('gulp-tslint');
 var del = require('del');
 var argv = require('yargs').argv;
 var istanbul = require('gulp-istanbul');
+var tl = require('vsts-task-lib');
 
 // Default to list reporter when run directly.
 // CI build can pass 'reporter=junit' to create JUnit results files
@@ -102,6 +103,14 @@ gulp.task('test-coverage', function() {
           ));
     })
     .on('error', errorHandler);
+});
+
+//The following task is used by the CI build to upload code coverage files
+//Added due to race condition between writeReports and ccPublisher.publish
+//It's OK for this to fail if the coverage file doesn't exist
+gulp.task('upload-coverage-file', function() {
+    var ccPublisher = new tl.CodeCoveragePublisher();
+    ccPublisher.publish('cobertura', path.join(__dirname, 'out/results/coverage/cobertura-coverage.xml'), path.join(__dirname, 'out/results/coverage'), "");
 });
 
 gulp.task('test-all', ['test', 'test-integration'], function() { });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var del = require('del');
 var argv = require('yargs').argv;
 var istanbul = require('gulp-istanbul');
 var tl = require('vsts-task-lib');
+var path = require('path');
 
 // Default to list reporter when run directly.
 // CI build can pass 'reporter=junit' to create JUnit results files

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "tslint": "^2.5.0",
     "typescript": "^1.7.5",
     "vscode": "^0.11.x",
+    "vsts-task-lib": "^0.9.18",
     "yargs": "^5.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
I'm using the vsts-task-lib to upload the generated code coverage reports myself.  The code coverage feature of the Gulp build task can't be passed folders to ignore (only include), so I've got a task to run code coverage myself.  I'm adding a separate task here to upload the files as I've run into a race condition between when the my gulp task expects the report files to be available and when gulp-istanbul.writeReports() actually finishes writing them.  (This task is a workaround but the issue will need to be addressed later.)  The build definitions will need to call this new gulp task at the end of the build.

Also, the tasklib seems to leave a .taskkey file in the root of the repo (add it to .gitignore).