### PR TITLE
Allow markdown in Marketplace to render as GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "1.104.1",
   "publisher": "ms-vsts",
   "icon": "assets/team.png",
+  "markdown": "standard",
   "galleryBanner": {
     "color": "#65217C",
     "theme": "dark"


### PR DESCRIPTION
Currently, the VS Marketplace doesn't render Markdown like GitHub does.  As a result, the README.md renders differently (correctly) on GitHub than on the Visual Studio Marketplace (which adds embedded newlines).  The property I'm including here should force the Marketplace to render Markdown just like GitHub.

From the feature team:
_We have introduced a new property in manifest file of the extension. For VS Code extensions, you can add “markdown”: “standard” to package.json file of your extension and get rendering similar to that of GitHub. If you don’t add this property, then you will see current rendering behavior. If you are working on VSTS extension and want GitHub-like rendering, then you have to add "gitHubFlavoredMarkdown": "false" property to manifest file._