### PR TITLE
Disable collection of all unhandled exceptions

### DIFF
--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -37,6 +37,7 @@ export class TelemetryService {
                     .setAutoCollectConsole(false)
                     .setAutoCollectPerformance(false)
                     .setAutoCollectRequests(false)
+                    .setAutoCollectExceptions(false)
                     .start();
         this._appInsightsClient = appInsights.getClient(insightsKey);
         //Need to use HTTPS with v0.15.16 of App Insights


### PR DESCRIPTION
In our AI telemetry, many exceptions that we aren't explicitly sending to AppInsights are being logged in our AI data.  This change should prevent that.