### PR TITLE
Properly handle Team Services collections

### DIFF
--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -44,6 +44,9 @@ export class Strings {
     static UnableToRemoveCredentials: string = "Unable to remove credentials for this host.  You may need to remove them manually.  Host: ";
     static UnableToStoreCredentials: string = "Unable to store credentials for this host.  Host: ";
 
+    static UnableToValidateTeamServicesTfvcRepository: string = "Unable to validate the Team Services TFVC repository.";
+    static UnableToValidateTfvcRepositoryWithDefaultCollection: string = "Unable to validate the TFS TFVC repository with DefaultCollection.";
+
     //Status codes
     static StatusCode401: string = "Unauthorized. Check your authentication credentials and try again.";
     static StatusCodeOffline: string = "It appears Visual Studio Code is offline.  Please connect and try again.";


### PR DESCRIPTION
For Team Services, we don't need to provide the collection when getting the team project.  (I also localized a bit.)