### PR TITLE
Restrict Tfvc messages we display in VSC ui

### DIFF
--- a/src/team-extension.ts
+++ b/src/team-extension.ts
@@ -23,6 +23,7 @@ import { GitClient } from "./clients/gitclient";
 import { WitClient } from "./clients/witclient";
 import { RepositoryInfoClient } from "./clients/repositoryinfoclient";
 import { UserInfo } from "./info/userinfo";
+import { TfvcErrorCodes } from "./tfvc/tfvcerror";
 
 var os = require("os");
 var path = require("path");
@@ -457,7 +458,9 @@ export class TeamExtension  {
         } catch (err) {
             Logger.LogError(err.message);
             //For now, don't report these errors via the _feedbackClient
-            this.setErrorStatus(err.message, undefined, false);
+            if (!err.tfvcErrorCode || this.shouldDisplayTfvcError(err.tfvcErrorCode)) {
+                this.setErrorStatus(err.message, undefined, false);
+            }
         }
     }
 
@@ -651,6 +654,15 @@ export class TeamExtension  {
                 this.Reinitialize();
             });
         }
+    }
+
+    //Determines which Tfvc errors to display in the status bar ui
+    private shouldDisplayTfvcError(errorCode: string): boolean {
+        if (TfvcErrorCodes.TfvcMinVersionWarning === errorCode ||
+            TfvcErrorCodes.TfvcNotFound === errorCode) {
+            return true;
+        }
+        return false;
     }
 
     //Sets up the interval to refresh polling items

--- a/src/tfvc/tfvc.ts
+++ b/src/tfvc/tfvc.ts
@@ -34,7 +34,7 @@ export class Tfvc {
             if (!this._tfvcPath) {
                 throw new TfvcError({
                     message: Strings.TfvcLocationMissingError,
-                    tfvcErrorCode: TfvcErrorCodes.TfvcNotFound
+                    tfvcErrorCode: TfvcErrorCodes.TfvcLocationMissing
                 });
             }
         }

--- a/src/tfvc/tfvcerror.ts
+++ b/src/tfvc/tfvcerror.ts
@@ -77,6 +77,7 @@ export class TfvcErrorCodes {
     public static get RemoteConnectionError(): string { return "RemoteConnectionError"; }
     public static get DirtyWorkTree(): string { return "DirtyWorkTree"; }
     public static get CantOpenResource(): string { return "CantOpenResource"; }
+    public static get TfvcLocationMissing(): string { return "TfvcLocationMissing"; }
     public static get TfvcNotFound(): string { return "TfvcNotFound"; }
     public static get TfvcMinVersionWarning(): string { return "TfvcMinVersionWarning"; }
     public static get CantCreatePipe(): string { return "CantCreatePipe"; }


### PR DESCRIPTION
If tfvc.location is not yet set, don't display the message in the status bar ui.  If they've set it and set it improperly, go ahead and display that in the status bar.