### PR TITLE
Support external contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,21 @@
           "default": 5,
           "description": "Specify the number of minutes to wait when polling for new builds and pull requests."
         },
+        "team.remoteUrl": {
+          "type": "string",
+          "default": "",
+          "description": "Specify the url to a project collection to use when your source code repository is not hosted with Microsoft. Requires team.teamProject."
+        },
+        "team.teamProject": {
+          "type": "string",
+          "default": "",
+          "description": "Specify the team project to use when your source code repository is not hosted with Microsoft. Requires team.remoteUrl."
+        },
+        "team.buildDefinitionId": {
+          "type": "number",
+          "default": 0,
+          "description": "Specify the team project's build definition Id to monitor when your source code repository is not hosted with Microsoft. Requires both team.remoteUrl and team.teamProject."
+        },
         "tfvc.location": {
           "type": "string",
           "default": "",

--- a/src/clients/repositoryinfoclient.ts
+++ b/src/clients/repositoryinfoclient.ts
@@ -35,7 +35,7 @@ export class RepositoryInfoClient {
             repoInfo = await repositoryClient.getVstsInfo();
             repositoryInfo = new RepositoryInfo(repoInfo);
             return repositoryInfo;
-        } else if (this._repoContext.Type === RepositoryType.TFVC) {
+        } else if (this._repoContext.Type === RepositoryType.TFVC || this._repoContext.Type === RepositoryType.EXTERNAL) {
             Logger.LogDebug(`Getting repository information for a TFVC repository at ${this._repoContext.RemoteUrl}`);
             //For TFVC, the teamProjectName is retrieved by tf.cmd and set on the context
             let teamProjectName: string = this._repoContext.TeamProjectName;

--- a/src/contexts/gitcontext.ts
+++ b/src/contexts/gitcontext.ts
@@ -4,14 +4,15 @@
 *--------------------------------------------------------------------------------------------*/
 "use strict";
 
+import url = require("url");
 import { Utils } from "../helpers/utils";
 import { RepoUtils } from "../helpers/repoutils";
 import { IRepositoryContext, RepositoryType } from "./repositorycontext";
+import { ISettings } from "../helpers/settings";
 
 var pgc = require("parse-git-config");
 var gri = require("git-repo-info");
 var path = require("path");
-var url = require("url");
 
 //Gets as much information as it can regarding the Git repository without calling the server (vsts/info)
 export class GitContext implements IRepositoryContext {
@@ -95,8 +96,8 @@ export class GitContext implements IRepositoryContext {
     }
 
     //constructor already initializes the GitContext
-    public async Initialize(): Promise<void> {
-        return;
+    public async Initialize(settings: ISettings): Promise<boolean> {
+        return true;
     }
 
     //Git implementation

--- a/src/contexts/repocontextfactory.ts
+++ b/src/contexts/repocontextfactory.ts
@@ -7,28 +7,37 @@
 import { IRepositoryContext } from "../contexts/repositorycontext";
 import { GitContext } from "../contexts/gitcontext";
 import { TfvcContext } from "../contexts/tfvccontext";
+import { ExternalContext } from "../contexts/externalcontext";
+import { Settings } from "../helpers/settings";
 
 export class RepositoryContextFactory {
 
     //Returns an IRepositoryContext if the repository is either TFS or Team Services
-    public static async CreateRepositoryContext(path: string, gitDir?: string /*testing*/) : Promise<IRepositoryContext> {
+    public static async CreateRepositoryContext(path: string, settings: Settings) : Promise<IRepositoryContext> {
         let repoContext: IRepositoryContext;
+        let initialized: boolean = false;
 
-        //Check for Git first since it should be faster to determine and this code will
-        //be called on Reinitialize (when config changes, for example)
-        repoContext = new GitContext(path, gitDir);
-        if (!repoContext ||
-            repoContext.IsTeamFoundation === false) {
-            //Check if we have a TFVC repository
-            repoContext = new TfvcContext(path);
-            await repoContext.Initialize();
-            if (!repoContext ||
-                repoContext.IsTeamFoundation === false) {
-                //We don't have any Team Services repository
-                return undefined;
+        //Check for remoteUrl and teamProject in settings first
+        repoContext = new ExternalContext(path);
+        initialized = await repoContext.Initialize(settings);
+        if (!initialized) {
+            //Check for Git next since it should be faster to determine and this code will
+            //be called on Reinitialize (when config changes, for example)
+            repoContext = new GitContext(path);
+            initialized = await repoContext.Initialize(settings);
+            if (!repoContext || repoContext.IsTeamFoundation === false || !initialized) {
+                //Check if we have a TFVC repository
+                repoContext = new TfvcContext(path);
+                initialized = await repoContext.Initialize(settings);
+                if (!initialized) {
+                    return undefined;
+                }
+                if (repoContext.IsTeamFoundation === false) {
+                    //We don't have any Team Services repository
+                    return undefined;
+                }
             }
         }
-
         return repoContext;
     }
 

--- a/src/contexts/repositorycontext.ts
+++ b/src/contexts/repositorycontext.ts
@@ -4,17 +4,20 @@
 *--------------------------------------------------------------------------------------------*/
 "use strict";
 
+import { ISettings } from "../helpers/settings";
+
 export enum RepositoryType {
     GIT,
     TFVC,
-    ANY
+    ANY,
+    EXTERNAL
 }
 
 export interface IRepositoryContext {
     Type: RepositoryType;
 
     //Added Initialize() so TFVC could call tf.cmd async
-    Initialize(): Promise<void>;
+    Initialize(settings: ISettings): Promise<boolean>;
 
     IsSsh: boolean;
     IsTeamFoundation: boolean;
@@ -28,5 +31,5 @@ export interface IRepositoryContext {
     CurrentRef: string;
 
     //TFVC-specific values
-    TeamProjectName: string; //For TFVC, we can get this from the client
+    TeamProjectName: string;
 }

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -49,10 +49,14 @@ export class SettingNames {
     static AppInsights: string = SettingNames.SettingsPrefix + "appInsights.";
     static AppInsightsEnabled: string = SettingNames.AppInsights + "enabled";
     static AppInsightsKey: string = SettingNames.AppInsights + "key";
+    static RemoteUrl: string = SettingNames.SettingsPrefix + "remoteUrl";
+    static TeamProject: string = SettingNames.SettingsPrefix + "teamProject";
+    static BuildDefinitionId: string = SettingNames.SettingsPrefix + "buildDefinitionId";
 }
 
 export class TelemetryEvents {
     static TelemetryPrefix: string = Constants.ExtensionName + "/";
+    static ExternalRepository: string = TelemetryEvents.TelemetryPrefix + "externalrepo";
     static OpenAdditionalQueryResults: string = TelemetryEvents.TelemetryPrefix + "openaddlqueryresults";
     static OpenBlamePage: string = TelemetryEvents.TelemetryPrefix + "openblame";
     static OpenBuildSummaryPage: string = TelemetryEvents.TelemetryPrefix + "openbuildsummary";

--- a/src/helpers/settings.ts
+++ b/src/helpers/settings.ts
@@ -102,11 +102,24 @@ export class AccountSettings extends BaseSettings {
     }
 }
 
-export class Settings extends BaseSettings {
+export interface ISettings {
+    AppInsightsEnabled: boolean;
+    AppInsightsKey: string;
+    LoggingLevel: string;
+    PollingInterval: number;
+    RemoteUrl: string;
+    TeamProject: string;
+    BuildDefinitionId: number;
+}
+
+export class Settings extends BaseSettings implements ISettings {
     private _appInsightsEnabled: boolean;
     private _appInsightsKey: string;
     private _loggingLevel: string;
     private _pollingInterval: number;
+    private _remoteUrl: string;
+    private _teamProject: string;
+    private _buildDefinitionId: number;
 
     constructor() {
         super();
@@ -125,6 +138,9 @@ export class Settings extends BaseSettings {
 
         this._appInsightsEnabled = this.readSetting<boolean>(SettingNames.AppInsightsEnabled, true);
         this._appInsightsKey = this.readSetting<string>(SettingNames.AppInsightsKey, undefined);
+        this._remoteUrl = this.readSetting<string>(SettingNames.RemoteUrl, undefined);
+        this._teamProject = this.readSetting<string>(SettingNames.TeamProject, undefined);
+        this._buildDefinitionId = this.readSetting<number>(SettingNames.BuildDefinitionId, 0);
     }
 
     public get AppInsightsEnabled(): boolean {
@@ -141,5 +157,17 @@ export class Settings extends BaseSettings {
 
     public get PollingInterval(): number {
         return this._pollingInterval;
+    }
+
+    public get RemoteUrl(): string {
+        return this._remoteUrl;
+    }
+
+    public get TeamProject(): string {
+        return this._teamProject;
+    }
+
+    public get BuildDefinitionId(): number {
+        return this._buildDefinitionId;
     }
 }

--- a/src/info/repositoryinfo.ts
+++ b/src/info/repositoryinfo.ts
@@ -4,10 +4,9 @@
 *--------------------------------------------------------------------------------------------*/
 "use strict";
 
+import url = require("url");
 import { Logger } from "../helpers/logger";
 import { RepoUtils } from "../helpers/repoutils";
-
-var url = require("url");
 
 //When a RepositoryInfo object is created, we have already verified whether or not it
 //is either a Team Services or Team Foundation Server repository.  With the introduction
@@ -52,9 +51,9 @@ export class RepositoryInfo {
         let purl = url.parse(repositoryUrl);
         if (purl != null) {
             this._host = purl.host;
-            this._hostName = purl.hostName;
+            this._hostName = purl.hostname;
             this._path = purl.path;
-            this._pathName = purl.pathName;
+            this._pathName = purl.pathname;
             this._port = purl.port;
             this._protocol = purl.protocol;
             this._query = purl.query;

--- a/src/services/build.ts
+++ b/src/services/build.ts
@@ -51,9 +51,9 @@ export class BuildService {
     }
 
     //Construct the url to the individual build summary
-    //https://account.visualstudio.com/DefaultCollection/project/_build#_a=summary&buildId=1977
+    //https://account.visualstudio.com/DefaultCollection/project/_build/index?buildId=1977&_a=summary
     public static GetBuildSummaryUrl(remoteUrl: string, buildId: string) : string {
-        return BuildService.GetBuildsUrl(remoteUrl) + "#_a=summary" + "&buildId=" + buildId;
+        return BuildService.GetBuildsUrl(remoteUrl) + "/index?buildId=" + buildId + "&_a=summary";
     }
 
     //Construct the url to the build definitions page for the project

--- a/src/team-extension.ts
+++ b/src/team-extension.ts
@@ -40,7 +40,7 @@ export class TeamExtension  {
     //Gets any available build status information and adds it to the status bar
     public DisplayCurrentBranchBuildStatus(): void {
         if (this._manager.EnsureInitialized(RepositoryType.ANY)) {
-            this._buildClient.DisplayCurrentBuildStatus(this._manager.RepoContext, false);
+            this._buildClient.DisplayCurrentBuildStatus(this._manager.RepoContext, false, this._manager.Settings.BuildDefinitionId);
         } else {
             this._manager.DisplayErrorMessage();
         }
@@ -146,6 +146,8 @@ export class TeamExtension  {
                 this._gitClient.OpenFileHistory(this._manager.RepoContext);
             } else if (this._manager.RepoContext.Type === RepositoryType.TFVC) {
                 this._manager.Tfvc.TfvcViewHistory();
+            } else {
+                this._manager.DisplayErrorMessage(Strings.NoRepoInformation);
             }
         } else {
             this._manager.DisplayErrorMessage();
@@ -320,7 +322,7 @@ export class TeamExtension  {
     private pollBuildStatus(): void {
         if (this._manager.EnsureInitialized(RepositoryType.ANY)) {
             Logger.LogInfo("Polling for latest current build status...");
-            this._buildClient.DisplayCurrentBuildStatus(this._manager.RepoContext, true);
+            this._buildClient.DisplayCurrentBuildStatus(this._manager.RepoContext, true, this._manager.Settings.BuildDefinitionId);
         }
     }
 

--- a/test/contexts/externalcontext.test.ts
+++ b/test/contexts/externalcontext.test.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+"use strict";
+
+import { assert } from "chai";
+const path = require("path");
+
+import { RepositoryType } from "../../src/contexts/repositorycontext";
+import { ExternalContext }  from "../../src/contexts/externalcontext";
+import { ISettings }  from "../../src/helpers/settings";
+
+//Used to test the ExternalContext class
+class SettingsMock implements ISettings {
+    /* tslint:disable:variable-name */
+    constructor(public AppInsightsEnabled: boolean, public AppInsightsKey: string, public LoggingLevel: string,
+                public PollingInterval: number, public RemoteUrl: string, public TeamProject: string, public BuildDefinitionId: number) {
+        //nothing to do
+    }
+    /* tslint:enable:variable-name */
+}
+
+describe("ExternalContext", function() {
+    let TEST_REPOS_FOLDER: string = "testrepos";
+    let DOT_GIT_FOLDER: string = "dotgit";
+
+    beforeEach(function() {
+        // console.log("__dirname: " + __dirname);
+    });
+
+    it("should verify all undefined properties for undefined rootPath", function() {
+        //Verify an undefined path does not set any values
+        let ctx: ExternalContext = new ExternalContext(undefined);
+
+        assert.equal(ctx.CurrentRef, undefined);
+        assert.equal(ctx.CurrentBranch, undefined);
+        assert.equal(ctx.RepositoryParentFolder, undefined);
+        assert.isFalse(ctx.IsSsh);
+        assert.isFalse(ctx.IsTeamFoundation);
+        assert.isFalse(ctx.IsTeamServices);
+        assert.equal(ctx.RemoteUrl, undefined);
+        assert.equal(ctx.RepoFolder, undefined);
+        assert.equal(ctx.TeamProjectName, undefined);
+        assert.equal(ctx.Type, RepositoryType.EXTERNAL);
+    });
+
+    it("should verify values for valid rootPath path", function() {
+        let repoName: string = "gitrepo";
+        let repoPath: string = path.join(__dirname, TEST_REPOS_FOLDER, repoName, DOT_GIT_FOLDER);
+        //let gc: GitContext = new GitContext(repoPath, DOT_GIT_FOLDER);
+        let ctx: ExternalContext = new ExternalContext(repoPath);
+
+        assert.equal(ctx.CurrentRef, undefined);
+        assert.equal(ctx.CurrentBranch, undefined);
+        assert.equal(ctx.RepositoryParentFolder, undefined);
+        assert.isFalse(ctx.IsSsh);
+        assert.isFalse(ctx.IsTeamFoundation);
+        assert.isFalse(ctx.IsTeamServices);
+        assert.equal(ctx.RemoteUrl, undefined);
+        assert.equal(ctx.TeamProjectName, undefined);
+        assert.equal(ctx.Type, RepositoryType.EXTERNAL);
+
+        assert.equal(ctx.RepoFolder, repoPath);
+    });
+
+    it("should verify values for valid rootPath path and settings", async function() {
+        let repoName: string = "gitrepo";
+        let repoPath: string = path.join(__dirname, TEST_REPOS_FOLDER, repoName, DOT_GIT_FOLDER);
+        let ctx: ExternalContext = new ExternalContext(repoPath);
+
+        let mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, "https://xplatalm.visualstudio.com", "L2.VSCodeExtension.RC", undefined);
+        let initialized: Boolean = await ctx.Initialize(mock);
+
+        assert.isTrue(initialized);
+        assert.isTrue(ctx.IsTeamServices);
+        assert.isTrue(ctx.IsTeamFoundation);
+        assert.equal(ctx.RemoteUrl, mock.RemoteUrl);
+        assert.equal(ctx.TeamProjectName, mock.TeamProject);
+        assert.equal(ctx.Type, RepositoryType.EXTERNAL);
+    });
+
+    it("should verify initialize is false for missing RemoteUrl", async function() {
+        let repoName: string = "gitrepo";
+        let repoPath: string = path.join(__dirname, TEST_REPOS_FOLDER, repoName, DOT_GIT_FOLDER);
+        let ctx: ExternalContext = new ExternalContext(repoPath);
+
+        let mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, undefined, "L2.VSCodeExtension.RC", undefined);
+        let initialized: Boolean = await ctx.Initialize(mock);
+
+        assert.isFalse(initialized);
+        assert.isFalse(ctx.IsSsh);
+        assert.isFalse(ctx.IsTeamServices);
+        assert.isFalse(ctx.IsTeamFoundation);
+        assert.equal(ctx.RemoteUrl, undefined);
+        assert.equal(ctx.TeamProjectName, undefined);
+        assert.equal(ctx.Type, RepositoryType.EXTERNAL);
+    });
+
+    it("should verify initialize is false for missing TeamProject", async function() {
+        let repoName: string = "gitrepo";
+        let repoPath: string = path.join(__dirname, TEST_REPOS_FOLDER, repoName, DOT_GIT_FOLDER);
+        let ctx: ExternalContext = new ExternalContext(repoPath);
+
+        let mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, "https://xplatalm.visualstudio.com", undefined, undefined);
+        let initialized: Boolean = await ctx.Initialize(mock);
+
+        assert.isFalse(initialized);
+        assert.isFalse(ctx.IsSsh);
+        assert.isFalse(ctx.IsTeamServices);
+        assert.isFalse(ctx.IsTeamFoundation);
+        assert.equal(ctx.RemoteUrl, undefined);
+        assert.equal(ctx.TeamProjectName, undefined);
+        assert.equal(ctx.Type, RepositoryType.EXTERNAL);
+    });
+
+    it("should verify initialize is false for missing RemoteUrl and TeamProject", async function() {
+        let repoName: string = "gitrepo";
+        let repoPath: string = path.join(__dirname, TEST_REPOS_FOLDER, repoName, DOT_GIT_FOLDER);
+        let ctx: ExternalContext = new ExternalContext(repoPath);
+
+        let mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, undefined, undefined, undefined);
+        let initialized: Boolean = await ctx.Initialize(mock);
+
+        assert.isFalse(initialized);
+        assert.isFalse(ctx.IsSsh);
+        assert.isFalse(ctx.IsTeamServices);
+        assert.isFalse(ctx.IsTeamFoundation);
+        assert.equal(ctx.RemoteUrl, undefined);
+        assert.equal(ctx.TeamProjectName, undefined);
+        assert.equal(ctx.Type, RepositoryType.EXTERNAL);
+    });
+
+});

--- a/test/services/build.test.ts
+++ b/test/services/build.test.ts
@@ -33,7 +33,7 @@ describe("BuildService", function() {
         let url: string = "https://account.visualstudio.com/DefaultCollection/project";
         let arg: string = "42";
 
-        assert.equal(BuildService.GetBuildSummaryUrl(url, arg), url + "/_build#_a=summary&buildId=" + arg);
+        assert.equal(BuildService.GetBuildSummaryUrl(url, arg), url + "/_build/index?buildId=" + arg + "&_a=summary");
     });
 
     it("should verify GetBuildsUrl", function() {


### PR DESCRIPTION
That is, where the source repository isn't on Team Services.  This would allow the user to specify a collection url and team project name used to point to builds and work items.  Additionally, they can provide a build definition id to track a particular definition.