### PR TITLE
Making collection optional in argumentbuilder

### DIFF
--- a/src/tfvc/commands/add.ts
+++ b/src/tfvc/commands/add.ts
@@ -63,7 +63,8 @@ export class Add implements ITfvcCommand<string[]> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        return this.GetArguments();
+        return new ArgumentBuilder("add", this._serverContext, true /* skipCollectionOption */)
+            .AddAll(this._itemPaths);
     }
 
     public GetExeOptions(): any {

--- a/src/tfvc/commands/argumentbuilder.ts
+++ b/src/tfvc/commands/argumentbuilder.ts
@@ -15,7 +15,7 @@ export class ArgumentBuilder implements IArgumentProvider {
     private _arguments: string[] = [];
     private _secretArgumentIndexes: number[] = [];
 
-    public constructor(command: string, serverContext?: TeamServerContext) {
+    public constructor(command: string, serverContext?: TeamServerContext, skipCollectionOption?: boolean) {
         if (!command) {
             throw TfvcError.CreateArgumentMissingError("command");
         }
@@ -23,8 +23,10 @@ export class ArgumentBuilder implements IArgumentProvider {
         this.AddSwitch("noprompt");
 
         if (serverContext && serverContext.RepoInfo && serverContext.RepoInfo.CollectionUrl) {
-            //TODO decode URI since CLC does not expect encoded collection urls
-            this.AddSwitchWithValue("collection", serverContext.RepoInfo.CollectionUrl, false);
+            if (!skipCollectionOption) {
+                //TODO decode URI since CLC does not expect encoded collection urls
+                this.AddSwitchWithValue("collection", serverContext.RepoInfo.CollectionUrl, false);
+            }
             if (serverContext.CredentialInfo) {
                 this.AddSwitchWithValue("login", serverContext.CredentialInfo.Username + "," + serverContext.CredentialInfo.Password, true);
             }

--- a/src/tfvc/commands/delete.ts
+++ b/src/tfvc/commands/delete.ts
@@ -80,7 +80,8 @@ export class Delete implements ITfvcCommand<string[]> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        return this.GetArguments();
+        return new ArgumentBuilder("delete", this._serverContext, true /* skipCollectionOption */)
+            .AddAll(this._itemPaths);
     }
 
     public GetExeOptions(): any {

--- a/src/tfvc/commands/findconflicts.ts
+++ b/src/tfvc/commands/findconflicts.ts
@@ -86,7 +86,11 @@ export class FindConflicts implements ITfvcCommand<IConflict[]> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        return this.GetArguments();
+        const builder: ArgumentBuilder = new ArgumentBuilder("resolve", this._serverContext, true /* skipCollectionOption */)
+            .Add(this._itemPath)
+            .AddSwitch("recursive")
+            .AddSwitch("preview");
+        return builder;
     }
 
     public GetExeOptions(): any {

--- a/src/tfvc/commands/rename.ts
+++ b/src/tfvc/commands/rename.ts
@@ -76,7 +76,9 @@ export class Rename implements ITfvcCommand<string> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        return this.GetArguments();
+        return new ArgumentBuilder("rename", this._serverContext, true /* skipCollectionOption */)
+            .Add(this._sourcePath)
+            .Add(this._destinationPath);
     }
 
     public GetExeOptions(): any {

--- a/src/tfvc/commands/resolveconflicts.ts
+++ b/src/tfvc/commands/resolveconflicts.ts
@@ -68,7 +68,10 @@ export class ResolveConflicts implements ITfvcCommand<IConflict[]> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        return this.GetArguments();
+        const builder: ArgumentBuilder = new ArgumentBuilder("resolve", this._serverContext, true /* skipCollectionOption */)
+            .AddAll(this._itemPaths)
+            .AddSwitchWithValue("auto", AutoResolveType[this._autoResolveType], false);
+        return builder;
     }
 
     public GetExeOptions(): any {

--- a/src/tfvc/commands/sync.ts
+++ b/src/tfvc/commands/sync.ts
@@ -92,7 +92,15 @@ export class Sync implements ITfvcCommand<ISyncResults> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        return this.GetArguments();
+        const builder: ArgumentBuilder = new ArgumentBuilder("get", this._serverContext, true /* skipCollectionOption */)
+            .AddSwitch("nosummary")
+            .AddAll(this._itemPaths);
+
+        if (this._recursive) {
+            builder.AddSwitch("recursive");
+        }
+
+        return builder;
     }
 
     public GetExeOptions(): any {

--- a/src/tfvc/repository.ts
+++ b/src/tfvc/repository.ts
@@ -50,7 +50,7 @@ export class Repository {
     }
 
     public get HasContext(): boolean {
-        return this._serverContext !== undefined && this._serverContext.CredentialInfo !== undefined;
+        return this._serverContext !== undefined && this._serverContext.CredentialInfo !== undefined && this._serverContext.RepoInfo.CollectionUrl !== undefined;
     }
 
     public get Tfvc(): Tfvc {

--- a/src/tfvc/tfvc.ts
+++ b/src/tfvc/tfvc.ts
@@ -62,7 +62,7 @@ export class Tfvc {
             }
             this._isExe = path.extname(this._tfvcPath) === ".exe";
             if (this._isExe) {
-                this._minVersion = "14.102.0";  //Minimum tf.exe version
+                this._minVersion = "14.0.0";  //Minimum tf.exe version
             }
         } else {
             Logger.LogWarning(`TFVC ${this._tfvcPath} does not exist.`);


### PR DESCRIPTION
Many TF.exe commands will not accept the collection parameter. Updating those to tell the argumentbuilder not to include it.