### PR TITLE
Passing arguments more securly via stdin

### DIFF
--- a/src/contexts/externalcontext.ts
+++ b/src/contexts/externalcontext.ts
@@ -22,6 +22,10 @@ export class ExternalContext implements IRepositoryContext {
         this._folder = rootPath;
     }
 
+    public dispose() {
+        //nothing to do
+    }
+
     //Need to call tf.cmd to get TFVC information (and constructors can't be async)
     public async Initialize(settings: ISettings): Promise<boolean> {
         Logger.LogDebug(`Looking for an External Context at ${this._folder}`);

--- a/src/contexts/gitcontext.ts
+++ b/src/contexts/gitcontext.ts
@@ -95,6 +95,10 @@ export class GitContext implements IRepositoryContext {
         }
     }
 
+    public dispose() {
+        //nothing to do
+    }
+
     //constructor already initializes the GitContext
     public async Initialize(settings: ISettings): Promise<boolean> {
         return true;

--- a/src/contexts/repositorycontext.ts
+++ b/src/contexts/repositorycontext.ts
@@ -32,4 +32,7 @@ export interface IRepositoryContext {
 
     //TFVC-specific values
     TeamProjectName: string;
+
+    // implements disposable
+    dispose();
 }

--- a/src/contexts/tfvccontext.ts
+++ b/src/contexts/tfvccontext.ts
@@ -28,6 +28,13 @@ export class TfvcContext implements IRepositoryContext {
         this._tfvcFolder = rootPath;
     }
 
+    public dispose() {
+        if (this._tfvc) {
+            this._tfvc.dispose();
+            this._tfvc = undefined;
+        }
+    }
+
     //Need to call tf.cmd to get TFVC information (and constructors can't be async)
     public async Initialize(settings: ISettings): Promise<boolean> {
         Logger.LogDebug(`Looking for TFVC repository at ${this._tfvcFolder}`);

--- a/src/extensionmanager.ts
+++ b/src/extensionmanager.ts
@@ -461,6 +461,10 @@ export class ExtensionManager implements Disposable {
             this._tfvcExtension.dispose();
             this._tfvcExtension = undefined;
         }
+        if (this._repoContext) {
+            this._repoContext.dispose();
+            this._repoContext = undefined;
+        }
     }
 
     public dispose() {

--- a/src/tfvc/commands/argumentbuilder.ts
+++ b/src/tfvc/commands/argumentbuilder.ts
@@ -78,6 +78,36 @@ export class ArgumentBuilder implements IArgumentProvider {
         return this._arguments;
     }
 
+    /**
+     * This method builds all the arguments into a single command line. This is needed if
+     * a response file is needed for the commands.
+     */
+    public BuildCommandLine(): string {
+        let result: string = "";
+        this._arguments.forEach((arg) => {
+            const escapedArg = this.escapeArgument(arg);
+            result += escapedArg + " ";
+        });
+        result += "\n";
+        return result;
+    }
+
+    /**
+     * Command line arguments should have all embedded double quotes repeated to escape them.
+     * They should also be surrounded by double quotes if they contain a space (or other whitespace).
+     */
+    private escapeArgument(arg: string) {
+        if (!arg) {
+            return arg;
+        }
+
+        let escaped = arg.replace(/\"/g, "\"\"");
+        if (/\s/.test(escaped)) {
+            escaped = "\"" + escaped + "\"";
+        }
+        return escaped;
+    }
+
     public ToString(): string {
         let output: string = "";
         for (let i = 0; i < this._arguments.length; i++) {
@@ -99,6 +129,10 @@ export class ArgumentBuilder implements IArgumentProvider {
 
     public GetArguments(): string[] {
         return this.Build();
+    }
+
+    public GetCommandLine(): string {
+        return this.BuildCommandLine();
     }
 
     public GetArgumentsForDisplay(): string {

--- a/src/tfvc/interfaces.ts
+++ b/src/tfvc/interfaces.ts
@@ -118,6 +118,7 @@ export interface IArgumentProvider {
     AddProxySwitch(proxy: string);
     GetCommand(): string;
     GetArguments(): string[];
+    GetCommandLine(): string;
     GetArgumentsForDisplay(): string;
 }
 

--- a/src/tfvc/scm/model.ts
+++ b/src/tfvc/scm/model.ts
@@ -36,10 +36,9 @@ export class Model implements Disposable {
     public constructor(repositoryRoot: string, repository: Repository, onWorkspaceChange: Event<Uri>) {
         this._repositoryRoot = repositoryRoot;
         this._repository = repository;
-        // TODO handle $tf folder as well
-        const onNonGitChange = filterEvent(onWorkspaceChange, uri => !/\/\.tf\//.test(uri.fsPath));
+        // Ignore workspace changes that take place in the .tf or $tf folder (where path contains /.tf/ or \$tf\)
+        const onNonGitChange = filterEvent(onWorkspaceChange, uri => !/\/\.tf\//.test(uri.fsPath) && !/\\\$tf\\/.test(uri.fsPath));
         onNonGitChange(this.onFileSystemChange, this, this._disposables);
-        this.status();
     }
 
     public dispose() {
@@ -128,6 +127,7 @@ export class Model implements Disposable {
             await this.processDeletes(changes);
 
             // Get the list of conflicts
+            //TODO: Optimize out this call unless it is needed. This call takes over 4 times longer than the status call and is unecessary most of the time.
             foundConflicts = await this._repository.FindConflicts();
         }
 

--- a/src/tfvc/tfvc.ts
+++ b/src/tfvc/tfvc.ts
@@ -22,11 +22,12 @@ var _ = require("underscore");
 import * as fs from "fs";
 import * as path from "path";
 
-export class Tfvc {
+export class Tfvc implements IDisposable {
     private _tfvcPath: string;
     private _proxy: string;
     private _isExe: boolean = false;
     private _minVersion: string = "14.0.4";  //Minimum CLC version
+    private _tfRunner: TfRunner;
 
     public constructor(localPath?: string) {
         Logger.LogDebug(`TFVC Creating Tfvc object with localPath='${localPath}'`);
@@ -76,6 +77,16 @@ export class Tfvc {
                 tfvcErrorCode: TfvcErrorCodes.TfvcNotFound
             });
         }
+
+        // Setup the tf runner
+        this._tfRunner = new TfRunner(this._tfvcPath, { cwd: undefined });
+    }
+
+    public dispose() {
+        if (this._tfRunner) {
+            this._tfRunner.dispose();
+            this._tfRunner = undefined;
+        }
     }
 
     public get isExe(): boolean { return this._isExe; }
@@ -114,19 +125,6 @@ export class Tfvc {
     public async Exec(cwd: string, args: IArgumentProvider, options: any = {}): Promise<IExecutionResult> {
         // default to the cwd passed in, but allow options.cwd to overwrite it
         options = _.extend({ cwd }, options || {});
-        return await this._exec(args, options);
-    }
-
-    private spawn(args: IArgumentProvider, options: any = {}): cp.ChildProcess {
-        if (!options) {
-            options = {};
-        }
-
-        if (!options.stdio && !options.input) {
-            options.stdio = ["ignore", null, null]; // Unless provided, ignore stdin and leave default streams for stdout and stderr
-        }
-
-        options.env = _.assign({}, process.env, options.env || {});
 
         // TODO: do we want to handle proxies or not for the EXE? for tf.exe the user could simply setup the proxy at the command line.
         //       tf.exe remembers the proxy settings and uses them as it needs to.
@@ -139,23 +137,83 @@ export class Tfvc {
             TfvcOutput.AppendLine(`tf ${args.GetArgumentsForDisplay()}`);
         }
 
-        return cp.spawn(this._tfvcPath, args.GetArguments(), options);
+        return await this._tfRunner.Run(args, options, this._isExe);
+    }
+}
+
+class TfRunner implements IDisposable {
+    private _location: string;
+    private _options: any;
+    private _runningInstance: cp.ChildProcess;
+
+    public constructor(location: string, options: any) {
+        this._location = location;
+        this._options = options;
     }
 
-    private async _exec(args: IArgumentProvider, options: any = {}): Promise<IExecutionResult> {
-        const child = this.spawn(args, options);
-
-        if (options.input) {
-            child.stdin.end(options.input, "utf8");
+    public dispose() {
+        if (this._runningInstance) {
+            this._runningInstance.kill();
+            this._runningInstance = undefined;
         }
+    }
 
-        const result = await Tfvc.execProcess(child);
-        Logger.LogDebug(`TFVC exit code: ${result.exitCode}`);
+    public async Run(args: IArgumentProvider, options: any, isExe: boolean): Promise<IExecutionResult> {
+        const start: number = new Date().getTime();
+        const tfInstance: cp.ChildProcess = await this.getMatchingTfInstance(options);
+        // now that we have the matching one, start a new process (but don't wait on it to finish)
+        this.startNewTfInstance(options);
+
+        // Use the tf instance to perform the command
+        const argsForStandardInput: string = args.GetCommandLine();
+        const result: IExecutionResult = await this.runCommand(argsForStandardInput, tfInstance, isExe);
+
+        // log the results
+        const end: number = new Date().getTime();
+        Logger.LogDebug(`TFVC: ${args.GetCommand()} exit code: ${result.exitCode} (duration: ${end - start}ms)`);
+
         return result;
     }
 
-    private static async execProcess(child: cp.ChildProcess): Promise<IExecutionResult> {
+    private async getMatchingTfInstance(options: any): Promise<cp.ChildProcess> {
+        if (!this._runningInstance || !this.optionsMatch(options, this._options)) {
+            if (this._runningInstance) {
+                this._runningInstance.kill();
+            }
+            // spawn a new instance of TF with these options
+            await this.startNewTfInstance(options);
+        }
+        return this._runningInstance;
+    }
+
+    private async startNewTfInstance(options: any) {
+        // Start up a new instance of TF for later use
+        this._options = options;
+        this._runningInstance = await this.spawn(options);
+    }
+
+    private optionsMatch(options1: any, options2: any): boolean {
+        return (!options1 && !options2) || (options1.cwd === options2.cwd);
+    }
+
+    private async spawn(options: any): Promise<cp.ChildProcess> {
+        if (!options) {
+            options = {};
+        }
+        options.env = _.assign({}, process.env, options.env || {});
+
+        const start: number = new Date().getTime();
+        options.stdio = ["pipe", "pipe", "pipe"];
+        const child: cp.ChildProcess = await cp.spawn(this._location, ["@"], options);
+        const end: number = new Date().getTime();
+        Logger.LogDebug(`TFVC: spawned new process (duration: ${end - start}ms)`);
+        return child;
+    }
+
+    private async runCommand(argsForStandardInput: string, child: cp.ChildProcess, isExe: boolean): Promise<IExecutionResult> {
         const disposables: IDisposable[] = [];
+
+        child.stdin.end(argsForStandardInput, "utf8");
 
         const once = (ee: NodeJS.EventEmitter, name: string, fn: Function) => {
             ee.once(name, fn);
@@ -174,8 +232,22 @@ export class Tfvc {
             }),
             new Promise<string>(c => {
                 const buffers: string[] = [];
-                on(child.stdout, "data", b => buffers.push(b));
-                once(child.stdout, "close", () => c(buffers.join("")));
+                on(child.stdout, "data", b => {
+                    buffers.push(b);
+                });
+                once(child.stdout, "close", () => {
+                    let stdout: string = buffers.join("");
+                    if (isExe) {
+                        // TF.exe repeats the command line as part of the standard out when using the @ response file options
+                        // So, we look for the noprompt option to let us know where that line is so we can strip it off
+                        const start: number = stdout.indexOf("-noprompt");
+                        if (start >= 0) {
+                            const end: number = stdout.indexOf("\n", start);
+                            stdout = stdout.slice(end + 1);
+                        }
+                    }
+                    c(stdout);
+                });
             }),
             new Promise<string>(c => {
                 const buffers: string[] = [];

--- a/src/tfvc/tfvcscmprovider.ts
+++ b/src/tfvc/tfvcscmprovider.ts
@@ -174,6 +174,9 @@ export class TfvcSCMProvider implements SCMProvider {
             //autoFetcher,
             //mergeDecorator
         );
+
+        // Refresh the model now that we are done setting up
+        this._model.Refresh();
     }
 
     private cleanup() {

--- a/test/tfvc/commands/argumentbuilder.test.ts
+++ b/test/tfvc/commands/argumentbuilder.test.ts
@@ -67,10 +67,44 @@ describe("Tfvc-ArgumentBuilder", function() {
         assert.throws(() => new ArgumentBuilder(undefined), TfvcError, /Argument is required/);
     });
 
-    it("should verify GetArgumentsForDisplay", function() {
+    it("should verify ToString", function() {
         let cmd: string = "mycmd";
         let builder: ArgumentBuilder = new ArgumentBuilder(cmd, context);
         assert.equal(builder.ToString(), "mycmd -noprompt -collection:" + collectionUrl + " ********");
+    });
+
+    it("should verify BuildCommandLine with context", function() {
+        let cmd: string = "mycmd";
+        let builder: ArgumentBuilder = new ArgumentBuilder(cmd, context);
+        assert.equal(builder.BuildCommandLine().trim(), "mycmd -noprompt -collection:" + collectionUrl + " -login:" + user + "," + pass);
+    });
+
+    it("should verify BuildCommandLine", function() {
+        let cmd: string = "mycmd";
+        let builder: ArgumentBuilder = new ArgumentBuilder(cmd);
+        assert.equal(builder.BuildCommandLine().trim(), "mycmd -noprompt");
+    });
+
+    it("should verify BuildCommandLine with spaces in options", function() {
+        let cmd: string = "mycmd";
+        let path: string = "/path/with a space/file.txt";
+        let option: string = "option with space";
+        let builder: ArgumentBuilder = new ArgumentBuilder(cmd);
+        builder.Add(path);
+        builder.AddSwitch(option);
+        builder.AddSwitchWithValue(option, path, false);
+        assert.equal(builder.BuildCommandLine().trim(), "mycmd -noprompt \"/path/with a space/file.txt\" \"-option with space\" \"-option with space:/path/with a space/file.txt\"");
+    });
+
+    it("should verify BuildCommandLine with spaces in some", function() {
+        let cmd: string = "mycmd";
+        let path: string = "/path/with a space/file.txt";
+        let option: string = "option";
+        let builder: ArgumentBuilder = new ArgumentBuilder(cmd);
+        builder.Add(path);
+        builder.AddSwitch(option);
+        builder.AddSwitchWithValue(option, path, false);
+        assert.equal(builder.BuildCommandLine().trim(), "mycmd -noprompt \"/path/with a space/file.txt\" -option \"-option:/path/with a space/file.txt\"");
     });
 
     it("should verify interface implemented", function() {
@@ -87,6 +121,8 @@ describe("Tfvc-ArgumentBuilder", function() {
         assert.equal(args.length, 4);
         // GetArgumentsForDisplay
         assert.equal(argProvider.GetArgumentsForDisplay(), "mycmd -noprompt -collection:" + collectionUrl + " ********");
+        // GetCommandLine
+        assert.equal(argProvider.GetCommandLine(), "mycmd -noprompt -collection:" + collectionUrl + " -login:" + user + "," + pass + " \n");
         // AddProxySwitch
         argProvider.AddProxySwitch("TFSProxy");
         assert.equal(argProvider.GetArgumentsForDisplay(), "mycmd -noprompt -collection:" + collectionUrl + " ******** -proxy:TFSProxy");


### PR DESCRIPTION
- Works for CLC and TF.EXE
- Fixed a related bug where the model was being refreshed too soon before everything was setup
- Had to add code to put arguments on a single line in the ArgBuilder
- Added tests to maintain code coverage
- Also pre-cache the TF process in advance of using it. Current cache only supports one command line at a time.
User Story #930304 and #930313