### PR TITLE
Ensure we fail the build on errors

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,8 @@ gulp.task('build', ['copyresources'], function () {
     let tsProject = typescript.createProject('./tsconfig.json');
     let tsResult = tsProject.src()
         .pipe(sourcemaps.init())
-        .pipe(tsProject());
+        .pipe(tsProject())
+        .on('error', errorHandler);
 
     return tsResult.js
         .pipe(sourcemaps.write('.', {


### PR DESCRIPTION
Otherwise, the build will continue even if errors are found (although the errors will be emitted to console/log).