### PR TITLE
Use pinned query text, show PAT nag message, stop signout message

### DIFF
--- a/src/clients/witclient.ts
+++ b/src/clients/witclient.ts
@@ -108,9 +108,10 @@ export class WitClient {
     }
 
     public async ChooseWorkItems(): Promise<string[]> {
-        Logger.LogInfo("Getting work items...");
+        Logger.LogInfo("Getting work items to choose from...");
+        let query: string = await this.getPinnedQueryText(); //gets either MyWorkItems, queryText or wiql of queryPath of PinnedQuery
         // TODO: There isn't a way to do a multi select pick list right now, but when there is we should change this to use it.
-        let workItem: BaseQuickPickItem = await window.showQuickPick(await this.getMyWorkItems(this._serverContext.RepoInfo.TeamProject, WitQueries.MyWorkItems), { matchOnDescription: true, placeHolder: Strings.ChooseWorkItem });
+        let workItem: BaseQuickPickItem = await window.showQuickPick(await this.getMyWorkItems(this._serverContext.RepoInfo.TeamProject, query), { matchOnDescription: true, placeHolder: Strings.ChooseWorkItem });
         if (workItem) {
             return ["#" + workItem.id + " - " + workItem.description];
         } else {

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -90,6 +90,7 @@ export class TelemetryEvents {
     static ShowMyWorkItemQueries: string = TelemetryEvents.TelemetryPrefix + "showmyworkitemqueries";
     static StartUp: string = TelemetryEvents.TelemetryPrefix + "startup";
     static TokenLearnMoreClick: string = TelemetryEvents.TelemetryPrefix + "tokenlearnmoreclick";
+    static TokenInSettings: string = TelemetryEvents.TelemetryPrefix + "tokeninsettings";
     static ViewPullRequest: string = TelemetryEvents.TelemetryPrefix + "viewpullrequest";
     static ViewPullRequests: string = TelemetryEvents.TelemetryPrefix + "viewpullrequests";
     static ViewMyWorkItems: string = TelemetryEvents.TelemetryPrefix + "viewmyworkitems";

--- a/src/helpers/settings.ts
+++ b/src/helpers/settings.ts
@@ -65,6 +65,7 @@ export class PinnedQuerySettings extends BaseSettings {
     }
 }
 
+//FUTURE: The AccountSettings class can be remove in VNEXT (documentation was removed in 1.104; Aug 2016)
 export class AccountSettings extends BaseSettings {
     private _teamServicesPersonalAccessToken: string;
 

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -21,6 +21,7 @@ export class Strings {
     static NoTfvcBuildsFound: string = "No builds were found for this repository. Click to view your team project's build definitions page.";
     static NoRepoInformation: string = "No Team Services or Team Foundation Server repository configuration was found.  Ensure you've opened a folder that contains a repository.";
     static NoSourceFileForBlame: string = "A source file must be opened to show blame information.";
+    static FoundTokenInSettings: string = "A PAT was found in your VS Code settings.  It will be ignored and you should remove it.  You may then need to run the 'team signin' command.";
 
     static SendAFrown: string = "Send a Frown";
     static SendASmile: string = "Send a Smile";

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -21,7 +21,7 @@ export class Strings {
     static NoTfvcBuildsFound: string = "No builds were found for this repository. Click to view your team project's build definitions page.";
     static NoRepoInformation: string = "No Team Services or Team Foundation Server repository configuration was found.  Ensure you've opened a folder that contains a repository.";
     static NoSourceFileForBlame: string = "A source file must be opened to show blame information.";
-    static FoundTokenInSettings: string = "A PAT was found in your VS Code settings.  It will be ignored and you should remove it.  You may then need to run the 'team signin' command.";
+    static FoundTokenInSettings: string = "A PAT was found in your VS Code settings.  It will be ignored and you should remove it.  You should now use the Sign In command to store your PAT in a secure location.";
 
     static SendAFrown: string = "Send a Frown";
     static SendASmile: string = "Send a Smile";

--- a/src/team-extension.ts
+++ b/src/team-extension.ts
@@ -112,7 +112,7 @@ export class TeamExtension  {
         if (this._manager.ServerContext !== undefined && this._manager.ServerContext.RepoInfo !== undefined && this._manager.ServerContext.RepoInfo.IsTeamFoundation === true) {
             this._manager.CredentialManager.RemoveCredentials(this._manager.ServerContext.RepoInfo.Host).then(() => {
                 Logger.LogInfo("Signout: Removed credentials for host '" + this._manager.ServerContext.RepoInfo.Host + "'");
-                this._manager.Reinitialize();
+                this._manager.Reinitialize(true);
             }).catch((reason) => {
                 let msg: string = Strings.UnableToRemoveCredentials + this._manager.ServerContext.RepoInfo.Host;
                 this._manager.ReportError(msg, reason, true);


### PR DESCRIPTION
Pinned query text will choose either the query specified in the user settings (which can be wiql or a query path) or a default of WitQueries.MyWorkItems.

We're removing support for PAT tokens in user settings so if we find one, send telemetry about it, ignore it, and display a warning message to the user.  Only show the warning (nag) message once (on initialization).  If re-initialization occurs, don't show the nag message again.  If VS Code is restarted and the token is still present, then we'll show the nag message again.

On signout, reinitialization happens.  When it does, we always show the message that there's no credentials stored for the account (duh; we just removed them).  So prevent that message from being shown when re-init happens via signout.