### PR TITLE
A couple of message updates

### DIFF
--- a/src/extensionmanager.ts
+++ b/src/extensionmanager.ts
@@ -11,7 +11,7 @@ import { CredentialManager } from "./helpers/credentialmanager";
 import { Logger } from "./helpers/logger";
 import { Strings } from "./helpers/strings";
 import { Utils } from "./helpers/utils";
-import { UrlMessageItem, VsCodeUtils } from "./helpers/vscodeutils";
+import { ButtonMessageItem, VsCodeUtils } from "./helpers/vscodeutils";
 import { RepositoryContextFactory } from "./contexts/repocontextfactory";
 import { IRepositoryContext, RepositoryType } from "./contexts/repositorycontext";
 import { TeamServerContext} from "./contexts/servercontext";
@@ -155,7 +155,7 @@ export class ExtensionManager implements Disposable {
     private displayNoCredentialsMessage(): void {
         let error: string = Strings.NoTeamServerCredentialsRunSignin;
         let displayError: string = Strings.NoTeamServerCredentialsRunSignin;
-        let messageItem: UrlMessageItem = undefined;
+        let messageItem: ButtonMessageItem = undefined;
         if (this._serverContext.RepoInfo.IsTeamServices === true) {
             messageItem = { title : Strings.LearnMore,
                             url : Constants.TokenLearnMoreUrl,

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -66,13 +66,14 @@ export class Strings {
     static TfVersionWarning: string = "The installed version of the TF command line does not meet the minimum suggested version. You may run into errors or limitations with certain commands until you upgrade. Minimum suggested version: ";
     static TfNoPendingChanges: string = "There are no matching pending changes.";
     static UndoChanges: string = "Undo Changes";
-    static NoChangesToCheckin: string = "There are no changes to checkin. Changes must be added to the 'Included' section to be checked in.";
+    static NoChangesToCheckin: string = "There are no changes to check in. Changes must be added to the 'Included' section to be checked in.";
     static AllFilesUpToDate: string = "All files are up to date.";
     static CommandRequiresFileContext: string = "This command requires a file context and can only be executed from the TFVC viewlet window.";
     static CommandRequiresExplorerContext: string = "This command requires a file context and can only be executed from the Explorer window.";
     static RenamePrompt: string = "Provide the new name for the file.";
     static NoMatchesFound: string = "No items match any of the file paths provided.";
     static NoWorkspaceMappings: string = "Could not find a workspace with mappings.  Perhaps the wrong version of TF is being used with the selected folder?";
+    static ShowTfvcOutput: string = "Show TFVC Output";
 
     // TFVC viewlet Strings
     static ExcludedGroupName: string = "Excluded changes";

--- a/src/helpers/vscodeutils.ts
+++ b/src/helpers/vscodeutils.ts
@@ -19,10 +19,11 @@ export class WorkItemQueryQuickPickItem extends BaseQuickPickItem {
     wiql: string;
 }
 
-export class UrlMessageItem implements MessageItem {
+export class ButtonMessageItem implements MessageItem {
     title: string;
-    url: string;
-    telemetryId: string;
+    url?: string;
+    command?: string;
+    telemetryId?: string;
 }
 
 export class VsCodeUtils {
@@ -59,9 +60,9 @@ export class VsCodeUtils {
     }
 
     //Allow ability to show additional buttons with the message and return any chosen one via Promise
-    public static ShowErrorMessageWithOptions(message: string, ...urlMessageItem: UrlMessageItem[]) : Q.Promise<UrlMessageItem> {
-        let promiseToReturn: Q.Promise<UrlMessageItem>;
-        let deferred = Q.defer<UrlMessageItem>();
+    public static ShowErrorMessageWithOptions(message: string, ...urlMessageItem: ButtonMessageItem[]) : Q.Promise<ButtonMessageItem> {
+        let promiseToReturn: Q.Promise<ButtonMessageItem>;
+        let deferred = Q.defer<ButtonMessageItem>();
         promiseToReturn = deferred.promise;
 
         //Use the typescript spread operator to pass the rest parameter to showErrorMessage

--- a/src/team-extension.ts
+++ b/src/team-extension.ts
@@ -10,7 +10,7 @@ import { CommandNames, Constants, TelemetryEvents, WitTypes } from "./helpers/co
 import { Logger } from "./helpers/logger";
 import { Strings } from "./helpers/strings";
 import { Utils } from "./helpers/utils";
-import { UrlMessageItem, VsCodeUtils } from "./helpers/vscodeutils";
+import { ButtonMessageItem, VsCodeUtils } from "./helpers/vscodeutils";
 import { RepositoryType } from "./contexts/repositorycontext";
 import { BuildClient } from "./clients/buildclient";
 import { GitClient } from "./clients/gitclient";
@@ -95,7 +95,7 @@ export class TeamExtension  {
                 }
             }
         } else {
-            let messageItem : UrlMessageItem = { title : Strings.LearnMore,
+            let messageItem : ButtonMessageItem = { title : Strings.LearnMore,
                                 url : Constants.ReadmeLearnMoreUrl,
                                 telemetryId: TelemetryEvents.ReadmeLearnMoreClick };
             VsCodeUtils.ShowErrorMessageWithOptions(Strings.NoRepoInformation, messageItem).then((item) => {

--- a/src/tfvc/commands/findconflicts.ts
+++ b/src/tfvc/commands/findconflicts.ts
@@ -79,7 +79,8 @@ export class FindConflicts implements ITfvcCommand<IConflict[]> {
                 }
                 conflicts.push({
                     localPath: localPath,
-                    type: type
+                    type: type,
+                    message: line
                 });
             }
         }

--- a/src/tfvc/commands/resolveconflicts.ts
+++ b/src/tfvc/commands/resolveconflicts.ts
@@ -59,7 +59,8 @@ export class ResolveConflicts implements ITfvcCommand<IConflict[]> {
             if (startIndex >= 0 && endIndex > startIndex) {
                 conflicts.push({
                     localPath: line.slice(startIndex + "Resolved ".length, endIndex),
-                    type: ConflictType.RESOLVED
+                    type: ConflictType.RESOLVED,
+                    message: line
                 });
             }
         }

--- a/src/tfvc/interfaces.ts
+++ b/src/tfvc/interfaces.ts
@@ -88,6 +88,7 @@ export interface ISyncResults {
 export interface IConflict {
     localPath: string;
     type: ConflictType;
+    message: string;
 }
 
 export enum AutoResolveType {

--- a/src/tfvc/scm/model.ts
+++ b/src/tfvc/scm/model.ts
@@ -13,6 +13,7 @@ import { Resource } from "./resource";
 import { ResourceGroup, IncludedGroup, ExcludedGroup, ConflictsGroup } from "./resourcegroups";
 import { IConflict, IPendingChange } from "../interfaces";
 import { ConflictType, GetStatuses, Status } from "./status";
+import { TfvcOutput } from "../tfvcoutput";
 
 import * as _ from "underscore";
 import * as path from "path";
@@ -129,6 +130,11 @@ export class Model implements Disposable {
             // Get the list of conflicts
             //TODO: Optimize out this call unless it is needed. This call takes over 4 times longer than the status call and is unecessary most of the time.
             foundConflicts = await this._repository.FindConflicts();
+            foundConflicts.forEach(conflict => {
+                if (conflict.message) {
+                    TfvcOutput.AppendLine(`[Resolve] ${conflict.message}`);
+                }
+            });
         }
 
         const conflict: IConflict = foundConflicts.find(c => c.type === ConflictType.NAME_AND_CONTENT || c.type === ConflictType.RENAME);

--- a/src/tfvc/tfvc-extension.ts
+++ b/src/tfvc/tfvc-extension.ts
@@ -6,14 +6,14 @@
 
 import * as path from "path";
 import url = require("url");
-import { Uri, window, workspace } from "vscode";
+import { commands, Uri, window, workspace } from "vscode";
 import { RepositoryType } from "../contexts/repositorycontext";
 import { TfvcContext } from "../contexts/tfvccontext";
 import { ExtensionManager } from "../extensionmanager";
-import { TfvcTelemetryEvents } from "../helpers/constants";
+import { TfvcCommandNames, TfvcTelemetryEvents } from "../helpers/constants";
 import { Strings } from "../helpers/strings";
 import { Utils } from "../helpers/utils";
-import { VsCodeUtils } from "../helpers/vscodeutils";
+import { ButtonMessageItem, VsCodeUtils } from "../helpers/vscodeutils";
 import { Telemetry } from "../services/telemetry";
 import { Resource } from "./scm/resource";
 import { TfvcSCMProvider } from "./tfvcscmprovider";
@@ -281,7 +281,12 @@ export class TfvcExtension  {
             if (err.stdout) { //TODO: perhaps just for 'Checkin'? Or the CLC?
                 TfvcOutput.AppendLine(VsCodeUtils.FormatMessage(`[${prefix}] ${err.stdout}`));
             }
-            this._manager.DisplayErrorMessage(err.message);
+            let messageItem : ButtonMessageItem = { title : Strings.ShowTfvcOutput, command: TfvcCommandNames.ShowOutput };
+            VsCodeUtils.ShowErrorMessageWithOptions(err.message, messageItem).then((item) => {
+                if (item) {
+                    commands.executeCommand<void>(item.command);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Add a button to Tfvc error messages users can click to open the TFVC Output window.

If there are conflicts via the 'resolve' command, show the conflict text in the TFVC Output window.