### PR TITLE
Always show 'included' group

### DIFF
--- a/src/tfvc/scm/model.ts
+++ b/src/tfvc/scm/model.ts
@@ -58,9 +58,7 @@ export class Model implements Disposable {
         if (this._conflictsGroup.resources.length > 0) {
             result.push(this._conflictsGroup);
         }
-        if (this._includedGroup.resources.length > 0) {
-            result.push(this._includedGroup);
-        }
+        result.push(this._includedGroup);
         result.push(this._excludedGroup);
         return result;
     }


### PR DESCRIPTION
I prefer to always have 'Included' showing instead of having it disappear as you move items between them.  'Conflicts' stays dynamic.