### PR TITLE
Disable functionalithy when no team project is found

### DIFF
--- a/src/clients/repositoryinfoclient.ts
+++ b/src/clients/repositoryinfoclient.ts
@@ -104,6 +104,9 @@ export class RepositoryInfoClient {
             Logger.LogDebug(`Getting team project...  Url: '${serverUrl}', collection name: '${collection.name}', and project: '${teamProjectName}'`);
             //For a Team Services collection, ignore the collectionName
             let resolvedRemoteUrl: string = url.resolve(serverUrl, isTeamServices ? "" : collection.name);
+
+            //Delay the check for a teamProjectName (don't fail here).  If we don't have one, that's OK for TFVC
+            //functionality.  We need to disable Team Services functionality if we can't find a team project later.
             let project: TeamProject = await this.getProjectFromServer(coreApiClient, resolvedRemoteUrl, teamProjectName);
             Logger.LogDebug(`Found a team project for url: '${serverUrl}', collection name: '${collection.name}', and project id: '${project.id}'`);
 

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -75,6 +75,7 @@ export class Strings {
     static CommandRequiresExplorerContext: string = "This command requires a file context and can only be executed from the Explorer window.";
     static RenamePrompt: string = "Provide the new name for the file.";
     static NoMatchesFound: string = "No items match any of the file paths provided.";
+    static NoTeamProjectFound: string = "No team project found for this repository. Team Services functionality has been disabled.";
     static NoWorkspaceMappings: string = "Could not find a workspace with mappings.  Perhaps the wrong version of TF is being used with the selected folder?";
     static ShowTfvcOutput: string = "Show TFVC Output";
 

--- a/src/team-extension.ts
+++ b/src/team-extension.ts
@@ -346,15 +346,19 @@ export class TeamExtension  {
     }
 
     public InitializeClients(repoType: RepositoryType) : void {
-        //We can initialize for any repo type (just skip _gitClient if not Git)
-        this._pinnedQuerySettings = new PinnedQuerySettings(this._manager.ServerContext.RepoInfo.Account);
-        this._buildClient = new BuildClient(this._manager.ServerContext, this._buildStatusBarItem);
-        //Don't initialize the Git client if we aren't a Git repository
-        if (repoType === RepositoryType.GIT) {
-            this._gitClient = new GitClient(this._manager.ServerContext, this._pullRequestStatusBarItem);
+        //Ensure that the repo type is good to go before we initialize the clients for it. If we
+        //can't get a team project for TFVC, we shouldn't initialize the clients.
+        if (this._manager.EnsureInitialized(repoType)) {
+            //We can initialize for any repo type (just skip _gitClient if not Git)
+            this._pinnedQuerySettings = new PinnedQuerySettings(this._manager.ServerContext.RepoInfo.Account);
+            this._buildClient = new BuildClient(this._manager.ServerContext, this._buildStatusBarItem);
+            //Don't initialize the Git client if we aren't a Git repository
+            if (repoType === RepositoryType.GIT) {
+                this._gitClient = new GitClient(this._manager.ServerContext, this._pullRequestStatusBarItem);
+            }
+            this._witClient = new WitClient(this._manager.ServerContext, this._pinnedQuerySettings.PinnedQuery, this._pinnedQueryStatusBarItem);
+            this.startPolling();
         }
-        this._witClient = new WitClient(this._manager.ServerContext, this._pinnedQuerySettings.PinnedQuery, this._pinnedQueryStatusBarItem);
-        this.startPolling();
     }
 
     private pollBuildStatus(): void {

--- a/src/tfvc/tfvc-extension.ts
+++ b/src/tfvc/tfvc-extension.ts
@@ -297,6 +297,8 @@ export class TfvcExtension  {
      * opens a web browser to the appropriate history page.
      */
     public async ViewHistory(): Promise<void> {
+        //Since this command provides Team Services functionality, we need
+        //to ensure it is initialized for Team Services
         if (!this._manager.EnsureInitialized(RepositoryType.TFVC)) {
             this._manager.DisplayErrorMessage();
             return;
@@ -338,7 +340,7 @@ export class TfvcExtension  {
     }
 
     private async displayErrors(funcToTry: (prefix) => Promise<void>, prefix: string): Promise<void> {
-        if (!this._manager.EnsureInitialized(RepositoryType.TFVC)) {
+        if (!this._manager.EnsureInitializedForTFVC()) {
             this._manager.DisplayErrorMessage();
             return;
         }


### PR DESCRIPTION
If the project is TFVC and we can't determine the team project, don't display the team project, build and work items status bar items (don't even initalize them).  Instead, set a message that the functionality is explicitly disabled.  #178