### PR TITLE
Removing ability to store token in User settings

### DIFF
--- a/src/clients/repositoryinfoclient.ts
+++ b/src/clients/repositoryinfoclient.ts
@@ -35,6 +35,7 @@ export class RepositoryInfoClient {
             repositoryClient = new TeamServicesApi(this._repoContext.RemoteUrl, [this._handler]);
             repoInfo = await repositoryClient.getVstsInfo();
             repositoryInfo = new RepositoryInfo(repoInfo);
+            Logger.LogDebug(`Finished getting repository information for a Git repository at ${this._repoContext.RemoteUrl}`);
             return repositoryInfo;
         } else if (this._repoContext.Type === RepositoryType.TFVC || this._repoContext.Type === RepositoryType.EXTERNAL) {
             Logger.LogDebug(`Getting repository information for a TFVC repository at ${this._repoContext.RemoteUrl}`);
@@ -65,6 +66,7 @@ export class RepositoryInfoClient {
                 // A full Team Foundation Server collection url is required for the validate call to succeed.
                 // So we try the url given. If that fails, we assume it is a server Url and the collection is
                 // the defaultCollection. If that assumption fails we return false.
+                Logger.LogDebug(`Starting the validation of the TFS TFVC repository collection Url ('${serverUrl}')`);
                 let valid: boolean = await this.validateTfvcCollectionUrl(serverUrl);
                 if (valid) {
                     let parts: string[] = this.splitTfvcCollectionUrl(serverUrl);
@@ -114,7 +116,10 @@ export class RepositoryInfoClient {
 
             //Now, create the JSON blob to send to new RepositoryInfo(repoInfo);
             repoInfo = this.getTfvcRepoInfoBlob(serverUrl, collection.id, collection.name, collection.url, project.id, project.name, project.description, project.url);
+            Logger.LogDebug(`Tfvc repository information blob:`);
+            Logger.LogObject(repoInfo);
             repositoryInfo = new RepositoryInfo(repoInfo);
+            Logger.LogDebug(`Finished getting repository information for a TFVC repository at ${this._repoContext.RemoteUrl}`);
             return repositoryInfo;
         }
         return repositoryInfo;

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -96,7 +96,6 @@ export class TelemetryEvents {
     static StartUp: string = TelemetryEvents.TelemetryPrefix + "startup";
     static TokenLearnMoreClick: string = TelemetryEvents.TelemetryPrefix + "tokenlearnmoreclick";
     static TokenShowMeClick: string = TelemetryEvents.TelemetryPrefix + "tokenshowmeclick";
-    static TokenInSettings: string = TelemetryEvents.TelemetryPrefix + "tokeninsettings";
     static UnsupportedServerVersion: string = TelemetryEvents.TelemetryPrefix + "unsupportedversion";
     static ViewPullRequest: string = TelemetryEvents.TelemetryPrefix + "viewpullrequest";
     static ViewPullRequests: string = TelemetryEvents.TelemetryPrefix + "viewpullrequests";

--- a/src/helpers/credentialmanager.ts
+++ b/src/helpers/credentialmanager.ts
@@ -5,7 +5,6 @@
 "use strict";
 
 import { IRequestHandler } from "vso-node-api/interfaces/common/VsoBaseInterfaces";
-import { Constants } from "../helpers/constants";
 import { CredentialInfo } from "../info/credentialinfo";
 import { TeamServerContext } from "../contexts/servercontext";
 import { CredentialStore } from "../credentialstore/credentialstore";
@@ -26,32 +25,15 @@ export class CredentialManager {
         return CredentialManager._credentialHandler;
     }
 
-    public GetCredentials(context: TeamServerContext, teamServicesToken: string) : Q.Promise<CredentialInfo> {
+    public GetCredentials(context: TeamServerContext) : Q.Promise<CredentialInfo> {
         let deferred: Q.Deferred<CredentialInfo> = Q.defer<CredentialInfo>();
 
         this.getCredentials(context).then((credInfo: CredentialInfo) => {
             if (credInfo !== undefined) {
-                // Prefer the settings file until folks remove the entry.  So even though we'll store
-                // it if it isn't present, use the settings until they remove it.  Otherwise, if they
-                // update it, we'll never use the update.
-                if (teamServicesToken !== undefined) {
-                    credInfo = new CredentialInfo(teamServicesToken);
-                }
                 CredentialManager._credentialHandler = credInfo.CredentialHandler;
                 deferred.resolve(credInfo);
             } else {
-                // If I find credentials in settings, store them (migrate them from settings to storage).
-                if (teamServicesToken !== undefined) {
-                    this.StoreCredentials(context.RepoInfo.Host, Constants.OAuth, teamServicesToken).then(() => {
-                        credInfo = new CredentialInfo(teamServicesToken);
-                        CredentialManager._credentialHandler = credInfo.CredentialHandler;
-                        deferred.resolve(credInfo);
-                    }).catch((reason) => {
-                        deferred.reject(reason);
-                    });
-                } else {
-                    deferred.resolve(undefined);
-                }
+                deferred.resolve(undefined);
             }
         }).catch((reason) => {
             deferred.reject(reason);

--- a/src/helpers/settings.ts
+++ b/src/helpers/settings.ts
@@ -65,44 +65,6 @@ export class PinnedQuerySettings extends BaseSettings {
     }
 }
 
-//FUTURE: The AccountSettings class can be remove in VNEXT (documentation was removed in 1.104; Aug 2016)
-export class AccountSettings extends BaseSettings {
-    private _teamServicesPersonalAccessToken: string;
-
-    constructor(account: string) {
-        super();
-        // Storing PATs by account in the configuration settings to make switching between accounts easier
-        this._teamServicesPersonalAccessToken = this.getAccessToken(account);
-    }
-
-    private getAccessToken(account: string) : string {
-        let tokens: any = this.readSetting<any[]>(SettingNames.AccessTokens, undefined);
-        if (tokens !== undefined) {
-            Logger.LogDebug("Found access tokens in user configuration settings.");
-            let global: string = undefined;
-            for (let index: number = 0; index < tokens.length; index++) {
-                let element: any = tokens[index];
-                if (element.account === account ||
-                    element.account === account + ".visualstudio.com") {
-                    return element.token;
-                } else if (element.account === "global") {
-                    global = element.token;
-                }
-            }
-            if (global !== undefined) {
-                Logger.LogDebug("No account-specific token found, using global token.");
-                return global;
-            }
-        }
-        Logger.LogDebug("No account-specific token or global token found.");
-        return undefined;
-    }
-
-    public get TeamServicesPersonalAccessToken() : string {
-        return this._teamServicesPersonalAccessToken;
-    }
-}
-
 export interface ISettings {
     AppInsightsEnabled: boolean;
     AppInsightsKey: string;

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -21,7 +21,6 @@ export class Strings {
     static NoTfvcBuildsFound: string = "No builds were found for this repository. Click to view your team project's build definitions page.";
     static NoRepoInformation: string = "No Team Services or Team Foundation Server repository configuration was found. Ensure you've opened a folder that contains a repository.";
     static NoSourceFileForBlame: string = "A source file must be opened to show blame information.";
-    static FoundTokenInSettings: string = "A PAT was found in your VS Code settings. It will be ignored and you should remove it. You should now use the Sign In command to store your PAT in a secure location.";
 
     static SendAFrown: string = "Send a Frown";
     static SendASmile: string = "Send a Smile";

--- a/test-integration/clients/teamservicesclient.integration.test.ts
+++ b/test-integration/clients/teamservicesclient.integration.test.ts
@@ -25,7 +25,7 @@ describe("TeamServicesClient-Integration", function() {
         return credentialManager.StoreCredentials(TestSettings.Account, TestSettings.AccountUser, TestSettings.Password);
     });
     beforeEach(function() {
-        return credentialManager.GetCredentials(ctx, undefined);
+        return credentialManager.GetCredentials(ctx);
     });
     //afterEach(function() { });
     after(function() {

--- a/test-integration/contexts/servercontext.integration.test.ts
+++ b/test-integration/contexts/servercontext.integration.test.ts
@@ -22,7 +22,7 @@ describe("ServerContext-Integration", function() {
         return credentialManager.StoreCredentials(TestSettings.Account, TestSettings.AccountUser, TestSettings.Password);
     });
     beforeEach(function() {
-        return credentialManager.GetCredentials(ctx, undefined);
+        return credentialManager.GetCredentials(ctx);
     });
     // afterEach(function() { });
     after(function() {

--- a/test-integration/helpers/credentialmanager.test.ts
+++ b/test-integration/helpers/credentialmanager.test.ts
@@ -35,46 +35,12 @@ describe("CredentialManager-Integration", function() {
     it("should verify store, get, remove credentials for Team Services (no token in settings)", async function() {
         try {
             await credentialManager.StoreCredentials(TestSettings.Account, TestSettings.AccountUser, TestSettings.Password);
-            let credInfo: CredentialInfo = await credentialManager.GetCredentials(ctx, undefined);
+            let credInfo: CredentialInfo = await credentialManager.GetCredentials(ctx);
             //For PATs, username stored with StoreCredentials doesn't matter (it's always returned as OAuth)
             assert.equal(credInfo.Username, Constants.OAuth);
             assert.equal(credInfo.Password, TestSettings.Password);
             await credentialManager.RemoveCredentials(TestSettings.Account);
-            credInfo = await credentialManager.GetCredentials(ctx, undefined);
-            //Ensure the creds we added get removed
-            assert.isUndefined(credInfo);
-        } catch (err) {
-            console.log(err);
-        }
-    });
-
-    it("should verify get and remove credentials for Team Services (with token in settings)", async function() {
-        try {
-            //Test scenario where the requested credential is not in the credential store but we're passing the token (from settings)
-            let credInfo: CredentialInfo = await credentialManager.GetCredentials(ctx, TestSettings.SettingsPassword);
-            //For PATs, username stored with StoreCredentials doesn't matter (it's always returned as OAuth)
-            assert.equal(credInfo.Username, Constants.OAuth);
-            assert.equal(credInfo.Password, TestSettings.SettingsPassword);
-            await credentialManager.RemoveCredentials(TestSettings.Account);
-            credInfo = await credentialManager.GetCredentials(ctx, undefined);
-            //Ensure the creds we added get removed
-            assert.isUndefined(credInfo);
-        } catch (err) {
-            console.log(err);
-        }
-    });
-
-    it("should verify store, get, remove credentials for Team Services (with token in settings)", async function() {
-        try {
-            //Test scenario where the requested credential is in the store but we're also passing the token (from settings)
-            await credentialManager.StoreCredentials(TestSettings.Account, TestSettings.AccountUser, TestSettings.Password);
-            let credInfo: CredentialInfo = await credentialManager.GetCredentials(ctx, TestSettings.SettingsPassword);
-            //For PATs, username stored with StoreCredentials doesn't matter (it's always returned as OAuth)
-            assert.equal(credInfo.Username, Constants.OAuth);
-            //We still expect to get the SettingsPassword and not Password
-            assert.equal(credInfo.Password, TestSettings.SettingsPassword);
-            await credentialManager.RemoveCredentials(TestSettings.Account);
-            credInfo = await credentialManager.GetCredentials(ctx, undefined);
+            credInfo = await credentialManager.GetCredentials(ctx);
             //Ensure the creds we added get removed
             assert.isUndefined(credInfo);
         } catch (err) {
@@ -90,12 +56,12 @@ describe("CredentialManager-Integration", function() {
             let password: string = "password";
 
             await credentialManager.StoreCredentials(account, username, password);
-            let credInfo: CredentialInfo = await credentialManager.GetCredentials(ctx, undefined);
+            let credInfo: CredentialInfo = await credentialManager.GetCredentials(ctx);
             assert.equal(credInfo.Domain, "domain");
             assert.equal(credInfo.Username, "user");
             assert.equal(credInfo.Password, password);
             await credentialManager.RemoveCredentials(account);
-            credInfo = await credentialManager.GetCredentials(ctx, undefined);
+            credInfo = await credentialManager.GetCredentials(ctx);
             //Ensure the creds we added get removed
             assert.isUndefined(credInfo);
         } catch (err) {

--- a/test-integration/services/build.integration.test.ts
+++ b/test-integration/services/build.integration.test.ts
@@ -26,7 +26,7 @@ describe("BuildService-Integration", function() {
         return credentialManager.StoreCredentials(TestSettings.Account, TestSettings.AccountUser, TestSettings.Password);
     });
     beforeEach(function() {
-        return credentialManager.GetCredentials(ctx, undefined);
+        return credentialManager.GetCredentials(ctx);
     });
     // afterEach(function() { });
     after(function() {

--- a/test-integration/services/gitvc.integration.test.ts
+++ b/test-integration/services/gitvc.integration.test.ts
@@ -25,7 +25,7 @@ describe("GitVcService-Integration", function() {
         return credentialManager.StoreCredentials(TestSettings.Account, TestSettings.AccountUser, TestSettings.Password);
     });
     beforeEach(function() {
-        return credentialManager.GetCredentials(ctx, undefined);
+        return credentialManager.GetCredentials(ctx);
     });
     // afterEach(function() { });
     after(function() {

--- a/test-integration/services/workitemtracking.integration.test.ts
+++ b/test-integration/services/workitemtracking.integration.test.ts
@@ -26,7 +26,7 @@ describe("WorkItemTrackingService-Integration", function() {
         return credentialManager.StoreCredentials(TestSettings.Account, TestSettings.AccountUser, TestSettings.Password);
     });
     beforeEach(function() {
-        return credentialManager.GetCredentials(ctx, undefined);
+        return credentialManager.GetCredentials(ctx);
     });
     // afterEach(function() { });
     after(function() {


### PR DESCRIPTION
In previous versions, we displayed a nag message about having a token in your user settings (prompting folks to move it out).  Now, we're removing that nag message and just ignoring (not checking for) a PAT in user settings.
