### PR TITLE
Handle signout properly

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,6 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(commands.registerCommand(CommandNames.ViewWorkItemQueries, () => _extensionManager.Team.ViewWorkItems()));
     context.subscriptions.push(commands.registerCommand(CommandNames.SendFeedback, () => _extensionManager.Team.SendFeedback()));
     context.subscriptions.push(commands.registerCommand(CommandNames.RefreshPollingStatus, () => _extensionManager.Team.RefreshPollingStatus()));
-    context.subscriptions.push(commands.registerCommand(CommandNames.Reinitialize, () => _extensionManager.Reinitialize()));
 
     // TFVC Commands
     context.subscriptions.push(commands.registerCommand(TfvcCommandNames.Status, () => _extensionManager.Tfvc.Status()));

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -21,6 +21,7 @@ export class Strings {
     static NoTfvcBuildsFound: string = "No builds were found for this repository. Click to view your team project's build definitions page.";
     static NoRepoInformation: string = "No Team Services or Team Foundation Server repository configuration was found. Ensure you've opened a folder that contains a repository.";
     static NoSourceFileForBlame: string = "A source file must be opened to show blame information.";
+    static UserMustSignIn: string = "You are signed out. Please run the 'team signin' command.";
 
     static SendAFrown: string = "Send a Frown";
     static SendASmile: string = "Send a Smile";

--- a/src/tfvc/tfvc-extension.ts
+++ b/src/tfvc/tfvc-extension.ts
@@ -344,6 +344,12 @@ export class TfvcExtension  {
             this._manager.DisplayErrorMessage();
             return;
         }
+        //This occurs in the case where we 1) sign in successfully, 2) sign out, 3) sign back in but with invalid credentials
+        //Essentially, the tfvcExtension.InitializeClients call hasn't been made successfully yet.
+        if (!this._repo) {
+            this._manager.DisplayErrorMessage(Strings.UserMustSignIn);
+            return;
+        }
 
         try {
             await funcToTry(prefix);


### PR DESCRIPTION
In order to handle sign-out properly, we need to remove some objects but not all (including SCM Provider). We also need to track whether we signed out or not.