### PR TITLE
Update RemoteUrl if we have no collection in workspace

### DIFF
--- a/src/contexts/tfvccontext.ts
+++ b/src/contexts/tfvccontext.ts
@@ -92,4 +92,9 @@ export class TfvcContext implements IRepositoryContext {
     public get Type(): RepositoryType {
         return RepositoryType.TFVC;
     }
+
+    //This is used if we need to update the RemoteUrl after validating the TFVC collection with the repositoryinfoclient
+    public set RemoteUrl(remoteUrl: string) {
+        this._tfvcRemoteUrl = remoteUrl;
+    }
 }


### PR DESCRIPTION
Fixes a corner case of #189.  I never updated the TFVC RemoteUrl once I determined I needed to use the 'DefaultCollection' (when we initially find it isn't a part of the collection returned by `tf workfold`).