### PR TITLE
Fix 'args.startsWith is not a function'

### DIFF
--- a/src/services/workitemtracking.ts
+++ b/src/services/workitemtracking.ts
@@ -113,9 +113,10 @@ export class WorkItemTrackingService {
         //Keep original sort order that wiql specified
         for (let index: number = 0; index < workItemIds.length; index++) {
             const item: WorkItem = workItems.find((i) => i.id === workItemIds[index]);
+            const id: string = item.id.toString();
             results.push({
-                id: item.fields[WorkItemFields.Id],
-                label: item.fields[WorkItemFields.Id] + "  [" + item.fields[WorkItemFields.WorkItemType] + "]",
+                id: id,
+                label: `${id} [${item.fields[WorkItemFields.WorkItemType]}]`,
                 description: item.fields[WorkItemFields.Title]
             });
         }


### PR DESCRIPTION
UrlBuilder introduced this issue (#203). The problem is that, when pushing the object onto results, id was being pushed as a number (not a string).  The client was then assuming the value was a string (since ...args was typed as string[]).  That type checking was no help here.