### PR TITLE
Change extension category to `SCM Providers`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "TFVC"
   ],
   "categories": [
-    "Other"
+    "SCM Providers"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
VSCode could automatically drive users to discover new SCM Providers in the Marketplace. For this, we need the extensions to have the correct category.

Related to Microsoft/vscode#25696