### PR TITLE
Handle _JAVA_OPTIONS env var (used to address a Java heap error)

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -14,6 +14,14 @@ import * as opener from "opener";
 
 export class Utils {
 
+    public static FormatMessage(message: string): string {
+        if (message) {
+            //Replace newlines with spaces
+            return message.replace(/\r\n/g, " ").replace(/\n/g, " ").trim();
+        }
+        return message;
+    }
+
     //gitDir provided for unit testing purposes
     public static FindGitFolder(startingPath: string, gitDir?: string): string {
         if (!fs.existsSync(startingPath)) { return undefined; }

--- a/src/helpers/vscodeutils.ts
+++ b/src/helpers/vscodeutils.ts
@@ -48,20 +48,12 @@ export class VsCodeUtils {
         return value;
     }
 
-    public static FormatMessage(message: string): string {
-        if (message) {
-            //Replace newlines with spaces
-            return message.replace(/\r\n/g, " ").replace(/\n/g, " ").trim();
-        }
-        return message;
-    }
-
     //We have a single method to display either simple messages (with no options) or messages
     //that have multiple buttons that can run commands, open URLs, send telemetry, etc.
     public static async ShowErrorMessage(message: string, ...urlMessageItem: IButtonMessageItem[]): Promise<void> {
         //The following "cast" allows us to pass our own type around (and not reference "vscode" via an import)
         const messageItems: ButtonMessageItem[] = <ButtonMessageItem[]>urlMessageItem;
-        const messageToDisplay: string = `(${Constants.ExtensionName}) ${VsCodeUtils.FormatMessage(message)}`;
+        const messageToDisplay: string = `(${Constants.ExtensionName}) ${Utils.FormatMessage(message)}`;
 
         //Use the typescript spread operator to pass the rest parameter to showErrorMessage
         const chosenItem: IButtonMessageItem = await window.showErrorMessage(messageToDisplay, ...messageItems);
@@ -80,6 +72,6 @@ export class VsCodeUtils {
     }
 
     public static ShowWarningMessage(message: string) {
-        window.showWarningMessage("(" + Constants.ExtensionName + ") " + VsCodeUtils.FormatMessage(message));
+        window.showWarningMessage("(" + Constants.ExtensionName + ") " + Utils.FormatMessage(message));
     }
 }

--- a/src/tfvc/tfvc-extension.ts
+++ b/src/tfvc/tfvc-extension.ts
@@ -342,10 +342,10 @@ export class TfvcExtension  {
         try {
             await funcToTry(prefix);
         } catch (err) {
-            TfvcOutput.AppendLine(VsCodeUtils.FormatMessage(`[${prefix}] ${err.message}`));
+            TfvcOutput.AppendLine(Utils.FormatMessage(`[${prefix}] ${err.message}`));
             //If we also have text in err.stdout, provide that to the output channel
             if (err.stdout) { //TODO: perhaps just for 'Checkin'? Or the CLC?
-                TfvcOutput.AppendLine(VsCodeUtils.FormatMessage(`[${prefix}] ${err.stdout}`));
+                TfvcOutput.AppendLine(Utils.FormatMessage(`[${prefix}] ${err.stdout}`));
             }
             const messageItem: IButtonMessageItem = { title : Strings.ShowTfvcOutput, command: TfvcCommandNames.ShowOutput };
             VsCodeUtils.ShowErrorMessage(err.message, messageItem);

--- a/test/tfvc/commands/getversion.test.ts
+++ b/test/tfvc/commands/getversion.test.ts
@@ -118,6 +118,27 @@ describe("Tfvc-GetVersionCommand", function() {
         }
     });
 
+    it("should verify parse output - java object heap error", async function() {
+        const cmd: GetVersion = new GetVersion();
+        const executionResult: IExecutionResult = {
+            exitCode: 1,
+            stdout: "Error occurred during initialization of VM\r\nCould not reserve enough space for 2097152KB object heap\r\n",
+            stderr: undefined
+        };
+
+        let threw: boolean = false;
+
+        try {
+            await cmd.ParseOutput(executionResult);
+        } catch (err) {
+            assert.equal(err.tfvcErrorCode, TfvcErrorCodes.NotFound);
+            assert.isTrue(err.message.startsWith(Strings.TfInitializeFailureError));
+            threw = true;
+        } finally {
+            assert.isTrue(threw, "Checking for Java object heap error did not throw an error.");
+        }
+    });
+
     it("should verify parse Exe output - error exit code", async function() {
         const cmd: GetVersion = new GetVersion();
         const executionResult: IExecutionResult = {


### PR DESCRIPTION
For whatever reason, some times the CLC can fail to initialize the Java VM (I've seen this on Windows; and I do have a 64-bit JRE installed).  When it fails, nothing happens in the VS Code UI (no error message, no TFVC initialization). After turning on logging, you see this:

![image](https://cloud.githubusercontent.com/assets/2796865/26011500/576ef6b8-371f-11e7-8f3c-51fe2e47f50e.png)
 
The TFVC errors line is blank (because we only log stderr, in this case where add returns 1, _stderr_ is blank but **_stdout_** has the error message).

When you try to run the command in a command prompt, you get the following:

![image](https://cloud.githubusercontent.com/assets/2796865/26011513/64e6b290-371f-11e7-9e42-c5b605e47b44.png)

That's what is causing the failure. After digging, you have to set the _JAVA_OPTIONS env var (either user or a system variable):
![image](https://cloud.githubusercontent.com/assets/2796865/26011523/73e08a6e-371f-11e7-9916-a14a5e96a581.png)

The CLC then outputs the following to _stdout_ (see the 'Picked up _JAVA_OPTIONS' line):
![image](https://cloud.githubusercontent.com/assets/2796865/26011545/8f5fe636-371f-11e7-87d1-f7d6c7b305e9.png)
 
(But notice that it actually runs.)

This PR is to handle the issue and ensure we display an error in the UI, like this:

![image](https://cloud.githubusercontent.com/assets/2796865/26011548/953fff46-371f-11e7-896d-3a4f3b584e5d.png)

 The error that comes back is added to the end of the displayed message (to give us some kind of hope on debugging). The same message is displayed on hover in the status bar 'Team <stop-sign>'.
