### PR TITLE
Ensure messageOptions contains a value (not undefined)

### DIFF
--- a/src/tfvc/tfvcerror.ts
+++ b/src/tfvc/tfvcerror.ts
@@ -57,7 +57,7 @@ export class TfvcError {
         }
 
         this.message = this.message || data.message || Strings.TfExecFailedError;
-        this.messageOptions = data.messageOptions;
+        this.messageOptions = data.messageOptions || [];
         this.stdout = data.stdout;
         this.stderr = data.stderr;
         this.exitCode = data.exitCode;


### PR DESCRIPTION
If we don't give messageOptions a default value, we can run into issues like this (shown on a French OS):

![image](https://cloud.githubusercontent.com/assets/2796865/26161593/5d5bfd42-3af2-11e7-8ad0-b213d33f4b57.png)

'undefined is not iterable' occurs because messageOptions is undefined and the showErrorMessage tries to iterate over it.
