### PR TITLE
Generate consistent telemetry id

### DIFF
--- a/src/extensionmanager.ts
+++ b/src/extensionmanager.ts
@@ -303,8 +303,6 @@ export class ExtensionManager implements Disposable {
                                 this._serverContext.UserInfo = new UserInfo(settings.authenticatedUser.id,
                                                                             settings.authenticatedUser.providerDisplayName,
                                                                             settings.authenticatedUser.customDisplayName);
-                                //Finally, update Telemetry with the user's specific collection id and user id
-                                Telemetry.Update(this._serverContext.RepoInfo.CollectionId, this._serverContext.UserInfo.Id);
 
                                 this.initializeStatusBars();
                                 await this.initializeClients(this._repoContext.Type);

--- a/src/info/repositoryinfo.ts
+++ b/src/info/repositoryinfo.ts
@@ -133,6 +133,9 @@ export class RepositoryInfo {
     public get IsTeamServices(): boolean {
         return this._isTeamServicesUrl;
     }
+    public get Protocol(): string {
+        return this._protocol;
+    }
     public get RepositoryId(): string {
         return this._repositoryId;
     }

--- a/test/info/repositoryinfo.test.ts
+++ b/test/info/repositoryinfo.test.ts
@@ -21,6 +21,7 @@ describe("RepositoryInfo", function() {
         assert.isTrue(repoInfo.IsTeamFoundationServer);
         assert.isFalse(repoInfo.IsTeamServices);
         assert.equal(repoInfo.RepositoryUrl, url);
+        assert.equal(repoInfo.Protocol, "http:");
 
         // For on-prem currently, these should not be set
         assert.equal(repoInfo.CollectionId, undefined);
@@ -77,6 +78,7 @@ describe("RepositoryInfo", function() {
         const repoInfo: RepositoryInfo = new RepositoryInfo("https://account.visualstudio.com/DefaultCollection/teamproject/_git/repositoryName");
         assert.equal(repoInfo.Host, "account.visualstudio.com");
         assert.equal(repoInfo.Account, "account");
+        assert.equal(repoInfo.Protocol, "https:");
         assert.isTrue(repoInfo.IsTeamServices);
         assert.isTrue(repoInfo.IsTeamFoundation);
     });


### PR DESCRIPTION
Also log protocol (e.g., http, https) to help understand effects of 401 errors.
