### PR TITLE
Ensure Keep-Alive is true for HTTPS connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Visual Studio Team Services Extension
+![Build Status](https://mseng.visualstudio.com/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/3167/badge?branch=master)
 ### *The extension now provides support for **Team Foundation Version Control (TFVC)**!*
 This extension allows you to connect to Team Services, manage your pull requests for your Git repositories as well as
 monitor builds and work items for your team project. It uses your local repository information to connect to either

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,6 +73,8 @@ gulp.task('publishall', ['publishbuild'], function () {
         .pipe(gulp.dest('./out/test/contexts/testrepos'));
     gulp.src(['./test/helpers/testrepos/**/*'])
         .pipe(gulp.dest('./out/test/helpers/testrepos'));
+    gulp.src(['./patches/vso-node-api/handlers/ntlm.js'])
+        .pipe(gulp.dest('./node_modules/vso-node-api/handlers'));
 });
 
 //Tests will fail with MODULE_NOT_FOUND if I try to run 'publishBuild' before test target

--- a/patches/vso-node-api/handlers/ntlm.js
+++ b/patches/vso-node-api/handlers/ntlm.js
@@ -1,0 +1,115 @@
+"use strict";
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+var http = require("http");
+var https = require("https");
+var _ = require("underscore");
+var ntlm = require("../opensource/node-http-ntlm/ntlm");
+var NtlmCredentialHandler = (function () {
+    function NtlmCredentialHandler(username, password, domain, workstation) {
+        this.username = username;
+        this.password = password;
+        if (domain !== undefined) {
+            this.domain = domain;
+        }
+        if (workstation !== undefined) {
+            this.workstation = workstation;
+        }
+    }
+    NtlmCredentialHandler.prototype.prepareRequest = function (options) {
+        // No headers or options need to be set.  We keep the credentials on the handler itself.
+        // If a (proxy) agent is set, remove it as we don't support proxy for NTLM at this time
+        if (options.agent) {
+            delete options.agent;
+        }
+    };
+    NtlmCredentialHandler.prototype.canHandleAuthentication = function (res) {
+        if (res && res.statusCode === 401) {
+            // Ensure that we're talking NTLM here
+            // Once we have the www-authenticate header, split it so we can ensure we can talk NTLM
+            var wwwAuthenticate = res.headers['www-authenticate'];
+            if (wwwAuthenticate !== undefined) {
+                var mechanisms = wwwAuthenticate.split(', ');
+                var idx = mechanisms.indexOf("NTLM");
+                if (idx >= 0) {
+                    // Check specifically for 'NTLM' since www-authenticate header can also contain
+                    // the Authorization value to use in the form of 'NTLM TlRMTVNT....AAAADw=='
+                    if (mechanisms[idx].length == 4) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    };
+    // The following method is an adaptation of code found at https://github.com/SamDecrock/node-http-ntlm/blob/master/httpntlm.js
+    NtlmCredentialHandler.prototype.handleAuthentication = function (httpClient, protocol, options, objs, finalCallback) {
+        // Set up the headers for NTLM authentication
+        var ntlmOptions = _.extend(options, {
+            username: this.username,
+            password: this.password,
+            domain: this.domain || '',
+            workstation: this.workstation || ''
+        });
+        var keepaliveAgent;
+        if (httpClient.isSsl === true) {
+            keepaliveAgent = new https.Agent({ keepAlive: true });
+        }
+        else {
+            keepaliveAgent = new http.Agent({ keepAlive: true });
+        }
+        var self = this;
+        // The following pattern of sending the type1 message following immediately (in a setImmediate) is
+        // critical for the NTLM exchange to happen.  If we removed setImmediate (or call in a different manner)
+        // the NTLM exchange will always fail with a 401.
+        this.sendType1Message(httpClient, protocol, ntlmOptions, objs, keepaliveAgent, function (err, res) {
+            if (err) {
+                return finalCallback(err, null, null);
+            }
+            setImmediate(function () {
+                self.sendType3Message(httpClient, protocol, ntlmOptions, objs, keepaliveAgent, res, finalCallback);
+            });
+        });
+    };
+    // The following method is an adaptation of code found at https://github.com/SamDecrock/node-http-ntlm/blob/master/httpntlm.js
+    NtlmCredentialHandler.prototype.sendType1Message = function (httpClient, protocol, options, objs, keepaliveAgent, callback) {
+        var type1msg = ntlm.createType1Message(options);
+        var type1options = {
+            headers: {
+                'Connection': 'keep-alive',
+                'Authorization': type1msg
+            },
+            timeout: options.timeout || 0,
+            agent: keepaliveAgent,
+            // don't redirect because http could change to https which means we need to change the keepaliveAgent
+            allowRedirects: false
+        };
+        type1options = _.extend(type1options, _.omit(options, 'headers'));
+        httpClient.requestInternal(protocol, type1options, objs, callback);
+    };
+    // The following method is an adaptation of code found at https://github.com/SamDecrock/node-http-ntlm/blob/master/httpntlm.js
+    NtlmCredentialHandler.prototype.sendType3Message = function (httpClient, protocol, options, objs, keepaliveAgent, res, callback) {
+        if (!res.headers['www-authenticate']) {
+            return callback(new Error('www-authenticate not found on response of second request'));
+        }
+        // parse type2 message from server:
+        var type2msg = ntlm.parseType2Message(res.headers['www-authenticate']);
+        // create type3 message:
+        var type3msg = ntlm.createType3Message(type2msg, options);
+        // build type3 request:
+        var type3options = {
+            headers: {
+                'Authorization': type3msg
+            },
+            allowRedirects: false,
+            agent: keepaliveAgent
+        };
+        // pass along other options:
+        type3options.headers = _.extend(type3options.headers, options.headers);
+        type3options = _.extend(type3options, _.omit(options, 'headers'));
+        // send type3 message to server:
+        httpClient.requestInternal(protocol, type3options, objs, callback);
+    };
+    return NtlmCredentialHandler;
+}());
+exports.NtlmCredentialHandler = NtlmCredentialHandler;


### PR DESCRIPTION
Should help to resolve #59 

I'm adding a private patch for NTLM.js in the vso-node-api module to properly set keep-alive for HTTPS connections.  Here's the change to the file: [Added keep-alive: true](https://github.com/Microsoft/vsts-vscode/compare/jeyou/https-keep-alive-patch?expand=1#diff-fc3b555bbca54671217e3d87553b1db4R56) for HTTPS connections.  

I'm doing a private patch because the vso-node-api has revved major versions (it underwent a major refactoring), is still in preview and NTLM support hasn't been added.  Updating vso-node-api can be done in a follow up user story.

In these changes, I've checked in a private version of ntlm.js and use the gulpfile to move it into the vso-node-api node_module before we do the packaging of the extension (it overwrites the existing file).  Doing this allows the packaged extension to contain the patched version.
