### PR TITLE
Add "More Details" button in scenario when Non-Enu TF.exe is configured

### DIFF
--- a/TFVC_README.md
+++ b/TFVC_README.md
@@ -198,6 +198,15 @@ Studio Code Settings (**File > Preferences > Settings**):
   ```
 
 ## Frequently Asked Questions
+### *I have received the "It appears you have configured a non-English version of the TF executable. Please ensure an English version is properly configured." error message after configuring TF.exe. How can I get the extension to work properly?*
+When TF.exe is configured as the tool to communicate with your TFS server (the TEE CLC does not have this problem), it will output status messages in
+the language of the configured operating system. So if the operating system is configured for German, the status messages will be output in German. The
+extension parses the output of TF.exe to show status in the SCM Viewlet. Today, the extension expects the messages to be output in English (thus the 
+error message you received). This message is an attempt to identify the issue.
+
+While there isn't a fix (e.g, an update to TF.exe that allows it to always output English status messages), one workaround is to rename the folder on disk from where the localized resources are being loaded by TF.exe. If the folder containing the localized resources cannot be located, the .NET Framework will fallback to the resources stored in TF.exe itself (the English ones). To locate the folder that needs to be renamed, open the folder that
+contains the TF.exe you have configured. In that folder are folders such as `de`, `fr`, `it`, `es`. Simply rename that folder with another name and restart Visual Studio Code. If you would rather not update that particular installation of Visual Studio (as such a change would affect Visual Studio as well), you can install the [standalone Team Explorer 2017 version of Visual Studio](#how-can-i-acquire-tfexe-do-i-need-a-version-of-visual-studio), configure the TF.exe that ships with it and rename the folder in that instance.
+
 ### *Is it required that I have a TFVC workspace already on my local machine to use the TFVC support?*
 Since release 1.116.0, yes, it is a requirement that you have an existing workspace on your local machine.
 

--- a/TFVC_README.md
+++ b/TFVC_README.md
@@ -198,7 +198,7 @@ Studio Code Settings (**File > Preferences > Settings**):
   ```
 
 ## Frequently Asked Questions
-### *I have received the "It appears you have configured a non-English version of the TF executable. Please ensure an English version is properly configured." error message after configuring TF.exe. How can I get the extension to work properly?*
+### *I received the "It appears you have configured a non-English version of the TF executable. Please ensure an English version is properly configured." error message after configuring TF.exe. How can I get the extension to work properly?*
 When TF.exe is configured as the tool to communicate with your TFS server (the TEE CLC does not have this problem), it will output status messages in
 the language of the configured operating system. So if the operating system is configured for German, the status messages will be output in German. The
 extension parses the output of TF.exe to show status in the SCM Viewlet. Today, the extension expects the messages to be output in English (thus the 

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -17,6 +17,7 @@ export class Constants {
     static ServerWorkspaceUrl: string = "https://github.com/Microsoft/vsts-vscode/blob/master/TFVC_README.md#what-is-the-difference-between-a-local-and-server-workspace-how-can-i-tell-which-one-im-working-with";
     static VS2015U3CSRUrl: string = "https://msdn.microsoft.com/en-us/library/mt752379.aspx";
     static WorkspaceNotDetectedByClcUrl: string = "https://github.com/Microsoft/vsts-vscode/blob/master/TFVC_README.md#using-the-tee-clc-i-am-unable-to-access-an-existing-local-workspace-what-can-i-do";
+    static NonEnuTfExeConfiguredUrl: string = "https://github.com/Microsoft/vsts-vscode/blob/master/TFVC_README.md#i-received-the-it-appears-you-have-configured-a-non-english-version-of-the-tf-executable-please-ensure-an-english-version-is-properly-configured-error-message-after-configuring-tfexe-how-can-i-get-the-extension-to-work-properly";
 }
 
 export class CommandNames {
@@ -123,6 +124,7 @@ class TfvcBaseTelemetryEvents {
     static GetFileContent: string = "getfilecontent";
     static LearnMoreClick: string = "learnmoreclick";
     static NameAndContentConflict: string = "nameandcontentconflict";
+    static NonEnuConfiguredMoreDetails: string = "nonenuconfiguredmoredetails";
     static OpenFileHistory: string = "openfilehistory";
     static OpenRepositoryHistory: string = "openrepohistory";
     static RenameConflict: string = "renameconflict";
@@ -170,6 +172,7 @@ export class TfvcTelemetryEvents {
     static UndoAllExe: string = TfvcTelemetryEvents.UsingExe + "-" + TfvcBaseTelemetryEvents.UndoAll;
     static UndoAllClc: string = TfvcTelemetryEvents.UsingClc + "-" + TfvcBaseTelemetryEvents.UndoAll;
     static ClcCannotAccessWorkspace: string = TfvcTelemetryEvents.UsingClc + "-" + TfvcBaseTelemetryEvents.WorkspaceAccessError;
+    static ExeNonEnuConfiguredMoreDetails: string = TfvcTelemetryEvents.UsingExe + "-" + TfvcBaseTelemetryEvents.NonEnuConfiguredMoreDetails;
 }
 
 export class WellKnownRepositoryTypes {

--- a/src/tfvc/commands/findworkspace.ts
+++ b/src/tfvc/commands/findworkspace.ts
@@ -6,6 +6,8 @@
 
 import * as path from "path";
 import { Strings } from "../../helpers/strings";
+import { IButtonMessageItem } from "../../helpers/vscodeutils.interfaces";
+import { Constants, TfvcTelemetryEvents } from "../../helpers/constants";
 import { IArgumentProvider, IExecutionResult, ITfvcCommand, IWorkspace, IWorkspaceMapping } from "../interfaces";
 import { ArgumentBuilder } from "./argumentbuilder";
 import { CommandHelper } from "./commandhelper";
@@ -128,8 +130,12 @@ export class FindWorkspace implements ITfvcCommand<IWorkspace> {
         //So if we determine there are mappings but can't get the workspace name, we assume it's a non-ENU
         //tf executable. One example of this is German.
         if (mappings.length > 0 && !workspaceName) {
+            const messageOptions: IButtonMessageItem[] = [{ title : Strings.MoreDetails,
+                                url : Constants.NonEnuTfExeConfiguredUrl,
+                                telemetryId: TfvcTelemetryEvents.ExeNonEnuConfiguredMoreDetails }];
             throw new TfvcError( {
                 message: Strings.NotAnEnuTfCommandLine,
+                messageOptions: messageOptions,
                 tfvcErrorCode: TfvcErrorCodes.NotAnEnuTfCommandLine
              });
         }

--- a/src/tfvc/commands/getversion.ts
+++ b/src/tfvc/commands/getversion.ts
@@ -9,6 +9,8 @@ import { ArgumentBuilder } from "./argumentbuilder";
 import { CommandHelper } from "./commandhelper";
 import { TfvcError, TfvcErrorCodes } from "../tfvcerror";
 import { Strings } from "../../helpers/strings";
+import { IButtonMessageItem } from "../../helpers/vscodeutils.interfaces";
+import { Constants, TfvcTelemetryEvents } from "../../helpers/constants";
 
 /**
  * This command calls the command line doing a simple call to get the help for the add command.
@@ -65,8 +67,12 @@ export class GetVersion implements ITfvcCommand<string> {
             return matches[matches.length - 1];
         } else {
             //If we can't find a version, that's pretty important. Therefore, we throw in this instance.
+            const messageOptions: IButtonMessageItem[] = [{ title : Strings.MoreDetails,
+                                url : Constants.NonEnuTfExeConfiguredUrl,
+                                telemetryId: TfvcTelemetryEvents.ExeNonEnuConfiguredMoreDetails }];
             throw new TfvcError({
                 message: Strings.NotAnEnuTfCommandLine,
+                messageOptions: messageOptions,
                 tfvcErrorCode: TfvcErrorCodes.NotAnEnuTfCommandLine
             });
         }


### PR DESCRIPTION
This PR is to help users with a non-ENU TF.exe know how to update their installation so their TF.exe outputs messages in English.  Basically, I'm adding a "More Details" button that will open their browser to the provided FAQ.