### PR TITLE
Add Welcome message on installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,6 +264,11 @@
           "default": 0,
           "description": "[Not for TFVC] Specify the team project's build definition Id to monitor when your source code repository is not hosted with Microsoft. Requires both team.remoteUrl and team.teamProject."
         },
+        "team.showWelcomeMessage": {
+          "type": "boolean",
+          "default": true,
+          "description": "Tracks whether the extension should display the Welcome message after the initial installation."
+        },
         "tfvc.location": {
           "type": "string",
           "default": "",

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -76,6 +76,7 @@ export class SettingNames {
     static RemoteUrl: string = SettingNames.SettingsPrefix + "remoteUrl";
     static TeamProject: string = SettingNames.SettingsPrefix + "teamProject";
     static BuildDefinitionId: string = SettingNames.SettingsPrefix + "buildDefinitionId";
+    static ShowWelcomeMessage: string = SettingNames.SettingsPrefix + "showWelcomeMessage";
 }
 
 export class TelemetryEvents {
@@ -109,6 +110,7 @@ export class TelemetryEvents {
     static ViewWorkItem: string = TelemetryEvents.TelemetryPrefix + "viewworkitem";
     static ViewWorkItems: string = TelemetryEvents.TelemetryPrefix + "viewworkitems";
     static VS2015U3CSR: string = TelemetryEvents.TelemetryPrefix + "vs2015u3csr";
+    static WelcomeLearnMoreClick: string = TelemetryEvents.TelemetryPrefix + "welcomelearnmoreclick";
 }
 
 //Don't export this class. TfvcTelemetryEvents is the only one which should be used when sending telemetry
@@ -148,6 +150,7 @@ export class TfvcTelemetryEvents {
     static RenameConflict: string = TfvcBaseTelemetryEvents.TelemetryPrefix + TfvcBaseTelemetryEvents.RenameConflict;
     static RestrictWorkspace: string = TfvcBaseTelemetryEvents.TelemetryPrefix + TfvcBaseTelemetryEvents.RestrictWorkspace;
     static StartUp: string = TfvcBaseTelemetryEvents.TelemetryPrefix + TfvcBaseTelemetryEvents.StartUp;
+    static SetupTfvcSupportClick: string = TfvcBaseTelemetryEvents.TelemetryPrefix + "setuptfvcsupportclick";
     //Begin tooling-specific telemetry (tf.exe or CLC)
     static ClcConfigured: string = TfvcTelemetryEvents.UsingClc + "-" + TfvcBaseTelemetryEvents.Configured;
     static ExeConfigured: string = TfvcTelemetryEvents.UsingExe + "-" + TfvcBaseTelemetryEvents.Configured;
@@ -188,5 +191,11 @@ export class WitQueries {
 export class WitTypes {
     static Bug: string = "Bug";
     static Task: string = "Task";
+}
+
+export enum MessageTypes {
+    Error = 0,
+    Warn = 1,
+    Info = 2
 }
 /* tslint:enable:variable-name */

--- a/src/helpers/settings.ts
+++ b/src/helpers/settings.ts
@@ -14,10 +14,15 @@ export abstract class BaseSettings {
         const value = configuration.get<T>(name, undefined);
 
         // If user specified a value, use it
-        if (value) {
+        if (value !== undefined) {
             return value;
         }
         return defaultValue;
+    }
+
+    protected writeSetting(name: string, value: any, global?: boolean): void {
+        const configuration = workspace.getConfiguration();
+        configuration.update(name, value, global);
     }
 }
 
@@ -73,6 +78,7 @@ export interface ISettings {
     RemoteUrl: string;
     TeamProject: string;
     BuildDefinitionId: number;
+    ShowWelcomeMessage: boolean;
 }
 
 export class Settings extends BaseSettings implements ISettings {
@@ -83,6 +89,7 @@ export class Settings extends BaseSettings implements ISettings {
     private _remoteUrl: string;
     private _teamProject: string;
     private _buildDefinitionId: number;
+    private _showWelcomeMessage: boolean;
 
     constructor() {
         super();
@@ -104,6 +111,7 @@ export class Settings extends BaseSettings implements ISettings {
         this._remoteUrl = this.readSetting<string>(SettingNames.RemoteUrl, undefined);
         this._teamProject = this.readSetting<string>(SettingNames.TeamProject, undefined);
         this._buildDefinitionId = this.readSetting<number>(SettingNames.BuildDefinitionId, 0);
+        this._showWelcomeMessage = this.readSetting<boolean>(SettingNames.ShowWelcomeMessage, true);
     }
 
     public get AppInsightsEnabled(): boolean {
@@ -132,5 +140,12 @@ export class Settings extends BaseSettings implements ISettings {
 
     public get BuildDefinitionId(): number {
         return this._buildDefinitionId;
+    }
+
+    public get ShowWelcomeMessage(): boolean {
+        return this._showWelcomeMessage;
+    }
+    public set ShowWelcomeMessage(value: boolean) {
+        this.writeSetting(SettingNames.ShowWelcomeMessage, value, true /*global*/);
     }
 }

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -31,11 +31,13 @@ export class Strings {
     static SendFeedbackPrompt: string = "Enter your feedback here (1000 char limit)";
     static NoFeedbackSent: string = "No feedback was sent.";
     static ThanksForFeedback: string = "Thanks for sending feedback!";
-    static LearnMore: string = "Learn more...";
-    static LearnMoreAboutTfvc: string = "TFVC support...";
-    static MoreDetails: string = "More details...";
+    static LearnMore: string = "Learn More...";
+    static LearnMoreAboutTfvc: string = "TFVC Support...";
+    static MoreDetails: string = "More Details...";
+    static SetupTfvcSupport: string = "Set Up TFVC Support...";
     static ShowMe: string = "Show Me!";
     static VS2015Update3CSR: string = "Get Latest VS 2015 Update";
+    static DontShowAgain: string = "Don't Show Again";
 
     static ChoosePullRequest: string = "Choose a pull request";
     static ChooseWorkItem: string = "Choose a work item";

--- a/test/contexts/contexthelper.ts
+++ b/test/contexts/contexthelper.ts
@@ -10,7 +10,8 @@ import { ISettings } from "../../src/helpers/settings";
 export class SettingsMock implements ISettings {
     /* tslint:disable:variable-name */
     constructor(public AppInsightsEnabled: boolean, public AppInsightsKey: string, public LoggingLevel: string,
-                public PollingInterval: number, public RemoteUrl: string, public TeamProject: string, public BuildDefinitionId: number) {
+                public PollingInterval: number, public RemoteUrl: string, public TeamProject: string, public BuildDefinitionId: number,
+                public ShowWelcomeMessage: boolean) {
         //nothing to do
     }
     /* tslint:enable:variable-name */

--- a/test/contexts/externalcontext.test.ts
+++ b/test/contexts/externalcontext.test.ts
@@ -67,7 +67,7 @@ describe("ExternalContext", function() {
         const repoPath: string = path.join(__dirname, TEST_REPOS_FOLDER, repoName, DOT_GIT_FOLDER);
         const ctx: ExternalContext = new ExternalContext(repoPath);
 
-        const mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, "https://xplatalm.visualstudio.com", "L2.VSCodeExtension.RC", undefined);
+        const mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, "https://xplatalm.visualstudio.com", "L2.VSCodeExtension.RC", undefined, true);
         const initialized: Boolean = await ctx.Initialize(mock);
 
         assert.isTrue(initialized);
@@ -83,7 +83,7 @@ describe("ExternalContext", function() {
         const repoPath: string = path.join(__dirname, TEST_REPOS_FOLDER, repoName, DOT_GIT_FOLDER);
         const ctx: ExternalContext = new ExternalContext(repoPath);
 
-        const mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, undefined, "L2.VSCodeExtension.RC", undefined);
+        const mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, undefined, "L2.VSCodeExtension.RC", undefined, true);
         const initialized: Boolean = await ctx.Initialize(mock);
 
         assert.isFalse(initialized);
@@ -100,7 +100,7 @@ describe("ExternalContext", function() {
         const repoPath: string = path.join(__dirname, TEST_REPOS_FOLDER, repoName, DOT_GIT_FOLDER);
         const ctx: ExternalContext = new ExternalContext(repoPath);
 
-        const mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, "https://xplatalm.visualstudio.com", undefined, undefined);
+        const mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, "https://xplatalm.visualstudio.com", undefined, undefined, true);
         const initialized: Boolean = await ctx.Initialize(mock);
 
         assert.isFalse(initialized);
@@ -117,7 +117,7 @@ describe("ExternalContext", function() {
         const repoPath: string = path.join(__dirname, TEST_REPOS_FOLDER, repoName, DOT_GIT_FOLDER);
         const ctx: ExternalContext = new ExternalContext(repoPath);
 
-        const mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, undefined, undefined, undefined);
+        const mock: SettingsMock = new SettingsMock(false, undefined, undefined, 1, undefined, undefined, undefined, true);
         const initialized: Boolean = await ctx.Initialize(mock);
 
         assert.isFalse(initialized);


### PR DESCRIPTION
Adding a Welcome message to help new users find out more about the extension (and how to set up TFVC support).  The option can be set to no longer show up ("Don't Show Again").

This is what it looks like:

![image](https://user-images.githubusercontent.com/2796865/27241868-79b25ea0-52a8-11e7-8f5f-c720e8371b96.png)
