### PR TITLE
Package file updates (updates for 'Associate Work Items' menu option)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "TFVC"
   ],
   "categories": [
-    "SCM Providers"
+    "SCM Providers",
+    "Other"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -133,16 +133,22 @@
         },
         {
           "command": "team.AssociateWorkItems",
-          "group": "3_commit@1"
+          "group": "3_commit@3",
+          "when": "scmProvider == tfvc"
+        },
+        {
+          "command": "team.AssociateWorkItems",
+          "group": "3_commit@5",
+          "when": "scmProvider == git"
         },
         {
           "command": "tfvc.Checkin",
-          "group": "3_commit@2",
+          "group": "3_commit@4",
           "when": "scmProvider == tfvc"
         },
         {
           "command": "tfvc.UndoAll",
-          "group": "3_commit@3",
+          "group": "3_commit@5",
           "when": "scmProvider == tfvc"
         },
         {


### PR DESCRIPTION
Should address #262.

Today, the 'Associate Work Items' menu item shows for all SCM providers (Hg, Perforce, TFVC and Git).  For Git, it shows even if it is not a VSTS/TFS hosted repository.  It is rendered for Git repositories like so:
![image](https://user-images.githubusercontent.com/2796865/27592306-2262a088-5b22-11e7-946a-f659eda22acd.png)
This PR changes the order so that it now appears like this:
![image](https://user-images.githubusercontent.com/2796865/27592331-310b3fa0-5b22-11e7-9166-b1e534404cfd.png)
(I think it makes the UI better in keeping the Git commands grouped together.)
The TFVC option remains unchanged:
![image](https://user-images.githubusercontent.com/2796865/27592365-4ce8965a-5b22-11e7-9eaf-e4408256d6ab.png)
And this is how it looks for Perforce (the 'Associate Work Items' menu is missing):
![image](https://user-images.githubusercontent.com/2796865/27592384-597db81e-5b22-11e7-8b19-8c88575516d1.png)

Note that I could not use an OR in a "when clause" due to it being [a missing feature](https://github.com/Microsoft/vscode/issues/22778). Therefore, I added two commands... one specifically for Git and the other specifically for TFVC.

Finally, for Git repositories that are not hosted on VSTS/TFS, I default to showing this message:
![image](https://user-images.githubusercontent.com/2796865/27554370-312dd34a-5a7c-11e7-88dc-7e30cdb747d9.png)
