### PR TITLE
Several miscellaneous fixes

### DIFF
--- a/src/clients/feedbackclient.ts
+++ b/src/clients/feedbackclient.ts
@@ -26,7 +26,7 @@ export class FeedbackClient {
                 const value: string = await window.showInputBox({ value: undefined, prompt: Strings.SendFeedbackPrompt, placeHolder: undefined, password: false });
                 if (value === undefined) {
                     const disposable = window.setStatusBarMessage(Strings.NoFeedbackSent);
-                    setInterval(() => disposable.dispose(), 1000 * 5);
+                    setTimeout(() => disposable.dispose(), 1000 * 5);
                     return;
                 }
 
@@ -35,7 +35,7 @@ export class FeedbackClient {
                 const email: string = await window.showInputBox({ value: undefined, prompt: Strings.SendEmailPrompt, placeHolder: undefined, password: false });
                 if (email === undefined) {
                     const disposable = window.setStatusBarMessage(Strings.NoFeedbackSent);
-                    setInterval(() => disposable.dispose(), 1000 * 5);
+                    setTimeout(() => disposable.dispose(), 1000 * 5);
                     return;
                 }
                 if (email) {
@@ -49,7 +49,7 @@ export class FeedbackClient {
                 Telemetry.SendFeedback(choice.id, { "VSCode.Feedback.Comment" : trimmedValue, "VSCode.Feedback.Email" : providedEmail} );
 
                 const disposable: Disposable = window.setStatusBarMessage(Strings.ThanksForFeedback);
-                setInterval(() => disposable.dispose(), 1000 * 5);
+                setTimeout(() => disposable.dispose(), 1000 * 5);
             }
         } catch (err) {
             const message: string = Utils.GetMessageForStatusCode(0, err.message, "Failed getting SendFeedback selection");

--- a/src/clients/witclient.ts
+++ b/src/clients/witclient.ts
@@ -39,7 +39,7 @@ export class WitClient extends BaseClient {
     public async CreateNewWorkItem(taskTitle: string): Promise<void> {
         try {
             Telemetry.SendEvent(TelemetryEvents.OpenNewWorkItem);
-            const selectedType: BaseQuickPickItem = await window.showQuickPick(await this.getWorkItemTypes(), { matchOnDescription: true, placeHolder: Strings.ChooseWorkItemType });
+            const selectedType: BaseQuickPickItem = await window.showQuickPick(this.getWorkItemTypes(), { matchOnDescription: true, placeHolder: Strings.ChooseWorkItemType });
             if (selectedType) {
                 Telemetry.SendEvent(TelemetryEvents.OpenNewWorkItem);
 
@@ -59,13 +59,13 @@ export class WitClient extends BaseClient {
     public async ShowMyWorkItemQueries(): Promise<void> {
         try {
             Telemetry.SendEvent(TelemetryEvents.ShowMyWorkItemQueries);
-            const query: WorkItemQueryQuickPickItem = await window.showQuickPick(await this.getMyWorkItemQueries(), { matchOnDescription: false, placeHolder: Strings.ChooseWorkItemQuery });
+            const query: WorkItemQueryQuickPickItem = await window.showQuickPick(this.getMyWorkItemQueries(), { matchOnDescription: false, placeHolder: Strings.ChooseWorkItemQuery });
             if (query) {
                 Telemetry.SendEvent(TelemetryEvents.ViewWorkItems);
                 Logger.LogInfo("Selected query is " + query.label);
                 Logger.LogInfo("Getting work items for query...");
 
-                const workItem: BaseQuickPickItem = await window.showQuickPick(await this.getMyWorkItems(this._serverContext.RepoInfo.TeamProject, query.wiql), { matchOnDescription: true, placeHolder: Strings.ChooseWorkItem });
+                const workItem: BaseQuickPickItem = await window.showQuickPick(this.getMyWorkItems(this._serverContext.RepoInfo.TeamProject, query.wiql), { matchOnDescription: true, placeHolder: Strings.ChooseWorkItem });
                 if (workItem) {
                     let url: string = undefined;
                     if (workItem.id === undefined) {
@@ -110,7 +110,7 @@ export class WitClient extends BaseClient {
         try {
             const query: string = await this.getPinnedQueryText(); //gets either MyWorkItems, queryText or wiql of queryPath of PinnedQuery
             // TODO: There isn't a way to do a multi select pick list right now, but when there is we should change this to use it.
-            const workItem: BaseQuickPickItem = await window.showQuickPick(await this.getMyWorkItems(this._serverContext.RepoInfo.TeamProject, query), { matchOnDescription: true, placeHolder: Strings.ChooseWorkItem });
+            const workItem: BaseQuickPickItem = await window.showQuickPick(this.getMyWorkItems(this._serverContext.RepoInfo.TeamProject, query), { matchOnDescription: true, placeHolder: Strings.ChooseWorkItem });
             if (workItem) {
                 return ["#" + workItem.id + " - " + workItem.description];
             } else {
@@ -124,7 +124,7 @@ export class WitClient extends BaseClient {
 
     private async showWorkItems(wiql: string): Promise<void> {
         Logger.LogInfo("Getting work items...");
-        const workItem: BaseQuickPickItem = await window.showQuickPick(await this.getMyWorkItems(this._serverContext.RepoInfo.TeamProject, wiql), { matchOnDescription: true, placeHolder: Strings.ChooseWorkItem });
+        const workItem: BaseQuickPickItem = await window.showQuickPick(this.getMyWorkItems(this._serverContext.RepoInfo.TeamProject, wiql), { matchOnDescription: true, placeHolder: Strings.ChooseWorkItem });
         if (workItem) {
             let url: string = undefined;
             if (workItem.id === undefined) {


### PR DESCRIPTION
First, the `setInterval` calls should be `setTimeout` as they should only be done once (since a message is being displayed on the status bar and it only needs to be cleared a single time).

Second, removing the `await` on the calls to showQuickPick actually allows the VS Code UI to show the status indicator on the Quick Pick.  Only the Pull Request quick picks were showing them; WIT-related reuqests were not.  I tracked it down to having added these awaits a while back.