### PR TITLE
Add 'device flow' authentication option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Should you wish to create a personal access token yourself, go [here](https://ak
 * TFVC repositories require tokens with *All Scopes*. Anything less will cause the extension to fail.
 
 #### Browser-based Authentication
-When using the new authentication experience, you will be prompted to copy a *device code* used to identify yourself to the authentication system. Once you accept the prompt to begin authentication, your default web browser will be opened to a login page. After supplying that device code and having it verified, you will then be prompted to authenticate with Team Services normally (e.g., username and password, multi-factor authentication, etc.). Once you are authenticated to Team Services, a personal access token will be created for you and the extension will be initialized normally. To see what this experience is like, [view this video]().
+When using the new authentication experience, you will be prompted to copy a *device code* used to identify yourself to the authentication system. Once you accept the prompt to begin authentication, your default web browser will be opened to a login page. After supplying that device code and having it verified, you will then be prompted to authenticate with Team Services normally (e.g., username and password, multi-factor authentication, etc.). Once you are authenticated to Team Services, a personal access token will be created for you and the extension will be initialized normally. To see what this experience is like, [view this video](https://youtu.be/HnDNdm1WCIo).
 
 ### Team Foundation Server
 If you are connecting to Team Foundation Server, you will only need your NTLM credentials (domain name, account name and password). It is assumed that you have the proper permissions on the TFS Server.

--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ To install the extension with the latest version of Visual Studio Code (version 
 
 ## Authentication
 ### Visual Studio Team Services
-If you are connecting to Team Services, you will need a personal access token (PAT) to securely access your account. The latest
-version of the extension will prompt for your token and store it securely. In previous versions of the extension, you needed to create a
-token and store it in your Visual Studio Code settings.
+If you are connecting to Team Services, you will need a personal access token (PAT) to securely access your account. With the release of v1.121.0 of the extension, you have a choice of whether you would like to create a token yourself manually and provide it when prompted, or use a new experience in which you are authenticated to Team Services using your web browser. In the new experience, a personal access token is still created in your account (on your behalf) but only after you are authenticated. The created token has *All Scopes* permissions but can be updated in your profile settings. Both tokens (manual or the new experience) are stored securely on your machine.
 
-If you do not have a personal access token yet, you will need to create one on your Team Services account.
-To create the token, go [here](https://aka.ms/gtgzt4) to read how. You can also [view our video](https://youtu.be/t6gGfj8WOgg) on how to do the same.
+#### Manual Token Creation
+Should you wish to create a personal access token yourself, go [here](https://aka.ms/gtgzt4) to read how. You can also [view our video](https://youtu.be/t6gGfj8WOgg) on how to do the same.
 * Git repositories require that you create your token with the **Build (read)**, **Code (read)** and **Work items (read)** scopes to ensure full functionality. You can also use *All Scopes*, but the minimum required scopes are those listed above.
 * TFVC repositories require tokens with *All Scopes*. Anything less will cause the extension to fail.
+
+#### Browser-based Authentication
+When using the new authentication experience, you will be prompted to copy a *device code* used to identify yourself to the authentication system. Once you accept the prompt to begin authentication, your default web browser will be opened to a login page. After supplying that device code and having it verified, you will then be prompted to authenticate with Team Services normally (e.g., username and password, multi-factor authentication, etc.). Once you are authenticated to Team Services, a personal access token will be created for you and the extension will be initialized normally. To see what this experience is like, [view this video]().
 
 ### Team Foundation Server
 If you are connecting to Team Foundation Server, you will only need your NTLM credentials (domain name, account name and password). It is assumed that you have the proper permissions on the TFS Server.

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -18,12 +18,14 @@ otherwise.
 7.  parse-git-config (https://github.com/jonschlinkert/parse-git-config)
 8.  path (https://github.com/jinder/path)
 9.  readable-stream (https://github.com/nodejs/readable-stream)
-10. underscore (https://github.com/jashkenas/underscore)
-11. uuid (https://github.com/kelektiv/node-uuid)
-12. vso-node-api (https://github.com/Microsoft/vso-node-api)
-13. winston (https://github.com/winstonjs/winston)
-14. xml2js (https://github.com/Leonidas-from-XIV/node-xml2js)
-15. xmldoc (https://github.com/nfarina/xmldoc)
+10. request-promise-native (https://github.com/request/request-promise-native)
+11. underscore (https://github.com/jashkenas/underscore)
+12. uuid (https://github.com/kelektiv/node-uuid)
+13. vso-node-api (https://github.com/Microsoft/vso-node-api)
+14. vsts-device-flow-auth (https://github.com/Microsoft/vsts-device-flow-auth)
+15. winston (https://github.com/winstonjs/winston)
+16. xml2js (https://github.com/Leonidas-from-XIV/node-xml2js)
+17. xmldoc (https://github.com/nfarina/xmldoc)
 
 
 %% Application Insights for Node.js NOTICES, INFORMATION, AND LICENSE BEGIN HERE
@@ -251,6 +253,26 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF readable-stream NOTICES, INFORMATION, AND LICENSE
 
+%% request-promise-native NOTICES, INFORMATION, AND LICENSE BEGIN HERE
+=========================================
+ISC License
+
+Copyright (c) 2017, Nicolai Kamenzky and contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+=========================================
+END OF request-promise-native NOTICES, INFORMATION, AND LICENSE
+
 %% underscore NOTICES, INFORMATION, AND LICENSE BEGIN HERE
 =========================================
 Copyright (c) 2009-2016 Jeremy Ashkenas, DocumentCloud and Investigative
@@ -331,6 +353,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =========================================
 END OF vso-node-api NOTICES, INFORMATION, AND LICENSE
+
+%% vsts-device-flow-auth NOTICES, INFORMATION, AND LICENSE BEGIN HERE
+=========================================
+MIT License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+=========================================
+END OF vsts-device-flow-auth NOTICES, INFORMATION, AND LICENSE
 
 %% winston NOTICES, INFORMATION, AND LICENSE BEGIN HERE
 =========================================

--- a/package.json
+++ b/package.json
@@ -515,10 +515,12 @@
     "parse-git-config": "^0.3.1",
     "path": "^0.12.7",
     "readable-stream": "^2.1.4",
+    "request-promise-native": "^1.0.4",
     "underscore": "^1.8.3",
     "url": "^0.11.0",
     "uuid": "^3.0.1",
     "vso-node-api": "^5.1.1",
+    "vsts-device-flow-auth": "^1.121.0",
     "winston": "2.3.1",
     "xml2js": "^0.4.17",
     "xmldoc": "^0.5.1"

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -42,6 +42,13 @@ export class CommandNames {
     static ViewPinnedQueryWorkItems: string = CommandNames.CommandPrefix + "ViewPinnedQueryWorkItems";
 }
 
+export class DeviceFlowConstants {
+    static ManualOption: string = "manual";
+    static DeviceFlowOption: string = "deviceflow";
+    static ClientId: string = "97877f11-0fc6-4aee-b1ff-febb0519dd00";
+    static RedirectUri: string = "https://java.visualstudio.com";
+}
+
 export class TfvcCommandNames {
     static CommandPrefix: string = "tfvc.";
     static Checkin: string = TfvcCommandNames.CommandPrefix + "Checkin";
@@ -82,8 +89,10 @@ export class SettingNames {
 export class TelemetryEvents {
     static TelemetryPrefix: string = Constants.ExtensionName + "/";
     static AssociateWorkItems: string = TelemetryEvents.TelemetryPrefix + "associateworkitems";
+    static DeviceFlowPat: string = TelemetryEvents.TelemetryPrefix + "deviceflowpat";
     static ExternalRepository: string = TelemetryEvents.TelemetryPrefix + "externalrepo";
     static Installed: string = TelemetryEvents.TelemetryPrefix + "installed";
+    static ManualPat: string = TelemetryEvents.TelemetryPrefix + "manualpat";
     static OpenAdditionalQueryResults: string = TelemetryEvents.TelemetryPrefix + "openaddlqueryresults";
     static OpenBlamePage: string = TelemetryEvents.TelemetryPrefix + "openblame";
     static OpenBuildSummaryPage: string = TelemetryEvents.TelemetryPrefix + "openbuildsummary";

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -24,6 +24,13 @@ export class Strings {
     static NoSourceFileForBlame: string = "A source file must be opened to show blame information.";
     static UserMustSignIn: string = "You are signed out. Please run the 'team signin' command.";
 
+    static DeviceFlowAuthenticatingToTeamServices: string = "Authenticating to Team Services (%s)...";
+    static DeviceFlowCopyCode: string = "Copy this code and then press Enter to start the authentication process";
+    static DeviceFlowManualPrompt: string = "Provide an access token manually (current experience)";
+    static DeviceFlowPrompt: string = "Authenticate and get an access token automatically (new experience)";
+    static DeviceFlowPlaceholder: string = "Choose your method of authenticating to Team Services...";
+    static ErrorRequestingToken: string = "An error occurred requesting a personal access token for %s.";
+
     static SendAFrown: string = "Send a Frown";
     static SendASmile: string = "Send a Smile";
     static SendEmailPrompt: string = "(Optional) Provide your email address";


### PR DESCRIPTION
This PR adds the option for users to authenticate with 'device flow' authentication (an automated web browser-based authentication mechanism) which makes it much simpler to get up and running with the extension.

_Note:_ I still need to update the link for the updated video I will be recording soon (https://github.com/Microsoft/vsts-vscode/commit/d0ce1333ed4085a74fde4dbc21df4a98d08efc5d#diff-04c6e90faac2675aa89e2176d2eec7d8R45).
