### PR TITLE
Fix for tf.exe domain authentication

### DIFF
--- a/src/tfvc/commands/argumentbuilder.ts
+++ b/src/tfvc/commands/argumentbuilder.ts
@@ -28,7 +28,7 @@ export class ArgumentBuilder implements IArgumentProvider {
                 this.AddSwitchWithValue("collection", serverContext.RepoInfo.CollectionUrl, false);
             }
             if (serverContext.CredentialInfo) {
-                this.AddSwitchWithValue("login", serverContext.CredentialInfo.Username + "," + serverContext.CredentialInfo.Password, true);
+                this.AddSwitchWithValue("login", (serverContext.CredentialInfo.Domain ? serverContext.CredentialInfo.Domain + "\\" : "") + serverContext.CredentialInfo.Username + "," + serverContext.CredentialInfo.Password, true);
             }
         }
     }


### PR DESCRIPTION
Fixes issue #246. On the Windows platform domain credentials are not included by the
argument builder.

This issue only affects credentials with a domain specified.  If the user specifies a username in this format: **domain\user** - when retrieved by the credential manager, the domain portion is split and returned in CredentialInfo.domain. This affects the argumentBuilder, the domain is not included when passing the "login" property to tf.exe.

This issue causes authentication to fail.  commandHelper.ProcessErrors assumes this is a local/server workspace issue and returns: 
```It appears you are using a Server workspace. Currently, TFVC support is limited to Local workspaces.```

A possible workaround may be to use TEE-CLC and pass credentials in **user@domain** format. TF.exe only accepts **domain\user** format.