### PR TITLE
Expose APIs for external extensions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,8 @@
 import { commands, ExtensionContext } from "vscode";
 import { CommandNames, TfvcCommandNames } from "./helpers/constants";
 import { ExtensionManager } from "./extensionmanager";
-import { AutoResolveType } from "./tfvc/interfaces";
+import { AutoResolveType, ICheckinInfo } from "./tfvc/interfaces";
+import { TfvcSCMProvider } from "./tfvc/tfvcscmprovider";
 
 let _extensionManager: ExtensionManager;
 
@@ -53,4 +54,21 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(commands.registerCommand(TfvcCommandNames.ShowOutput, () => _extensionManager.RunCommand(() => _extensionManager.Tfvc.ShowOutput())));
     context.subscriptions.push(commands.registerCommand(TfvcCommandNames.Checkin, () => _extensionManager.RunCommand(() => _extensionManager.Tfvc.Checkin())));
     context.subscriptions.push(commands.registerCommand(TfvcCommandNames.Sync, () => _extensionManager.RunCommand(() => _extensionManager.Tfvc.Sync())));
+
+    const api = {
+        getCheckinInfo() : ICheckinInfo {
+            return TfvcSCMProvider.GetCheckinInfo();
+        },
+        getRepositoryInfo() : any {
+            return {
+                collectionId : _extensionManager.ServerContext.RepoInfo.CollectionId,
+                projectName : _extensionManager.ServerContext.RepoInfo.TeamProject,
+                path : _extensionManager.ServerContext.RepoInfo.Path
+            };
+        },
+        checkin(checkinInfo : ICheckinInfo) {
+            return _extensionManager.Tfvc.Checkin(checkinInfo);
+        }
+    };
+    return api;
 }

--- a/src/info/repositoryinfo.ts
+++ b/src/info/repositoryinfo.ts
@@ -160,4 +160,7 @@ export class RepositoryInfo {
     public get TeamProject(): string {
         return this._teamProject;
     }
+    public get Path(): string {
+        return this._path;
+    }
 }

--- a/src/tfvc/interfaces.ts
+++ b/src/tfvc/interfaces.ts
@@ -32,6 +32,7 @@ export interface IItemInfo {
 export interface ICheckinInfo {
     comment: string;
     files: string[];
+    serverItems: string[];
     workItemIds: number[];
 }
 

--- a/src/tfvc/tfvc-extension.ts
+++ b/src/tfvc/tfvc-extension.ts
@@ -33,11 +33,11 @@ export class TfvcExtension  {
         this._manager = manager;
     }
 
-    public async Checkin(): Promise<void> {
+    public async Checkin(optionalCheckinInfo?: ICheckinInfo): Promise<void> {
         this.displayErrors(
             async () => {
-                // get the checkin info from the SCM viewlet
-                const checkinInfo: ICheckinInfo = TfvcSCMProvider.GetCheckinInfo();
+                // get the checkin info from arguments or the SCM viewlet
+                const checkinInfo: ICheckinInfo = optionalCheckinInfo || TfvcSCMProvider.GetCheckinInfo();
                 if (!checkinInfo) {
                     window.showInformationMessage(Strings.NoChangesToCheckin);
                     return;
@@ -47,7 +47,9 @@ export class TfvcExtension  {
                 const changeset: string =
                     await this._repo.Checkin(checkinInfo.files, checkinInfo.comment, checkinInfo.workItemIds);
                 TfvcOutput.AppendLine(`Changeset ${changeset} checked in.`);
-                TfvcSCMProvider.ClearCheckinMessage();
+                if (!optionalCheckinInfo) {
+                    TfvcSCMProvider.ClearCheckinMessage();
+                }
                 TfvcSCMProvider.Refresh();
             },
             "Checkin");

--- a/src/tfvc/tfvcscmprovider.ts
+++ b/src/tfvc/tfvcscmprovider.ts
@@ -50,6 +50,7 @@ export class TfvcSCMProvider {
 
         try {
             const files: string[] = [];
+            const serverItems: string[] = [];
             const commitMessage: string = scm.inputBox.value;
             const workItemIds: number[] = TfvcSCMProvider.getWorkItemIdsFromMessage(commitMessage);
 
@@ -60,10 +61,12 @@ export class TfvcSCMProvider {
 
             for (let i: number = 0; i < resources.length; i++) {
                 files.push(resources[i].PendingChange.localItem);
+                serverItems.push(resources[i].PendingChange.serverItem);
             }
 
             return {
                 files: files,
+                serverItems: serverItems,
                 comment: commitMessage,
                 workItemIds: workItemIds
             };


### PR DESCRIPTION
This change allows to implement external extensions which could execute build in CI for list of modified files. It exposes following APIs:

* Get details about modified files
* Get repository details
* Checkin changes

More details and use case in Microsoft/vscode#25838.