### PR TITLE
Fix interaction of TFVC repositories with TF.exe

### DIFF
--- a/src/tfvc/commands/add.ts
+++ b/src/tfvc/commands/add.ts
@@ -67,7 +67,7 @@ export class Add implements ITfvcCommand<string[]> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        return new ArgumentBuilder("add", this._serverContext, true /* skipCollectionOption */)
+        return new ArgumentBuilder("add", this._serverContext, true /* skipCollectionOption */, true /* isExe */)
             .AddAll(this._itemPaths);
     }
 

--- a/src/tfvc/commands/checkin.ts
+++ b/src/tfvc/commands/checkin.ts
@@ -87,10 +87,10 @@ export class Checkin implements ITfvcCommand<string> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        const builder: ArgumentBuilder = new ArgumentBuilder("checkin", this._serverContext, true /* skipCollectionOption */, true /* isExe */);
-        builder.AddSwitch("noprompt");
-        builder.RemoveSwitch("prompt");
-        builder.AddAll(this._files);
+        const builder: ArgumentBuilder = new ArgumentBuilder("checkin", this._serverContext, true /* skipCollectionOption */, true /* isExe */)
+            .AddSwitch("noprompt")
+            .RemoveSwitch("prompt")
+            .AddAll(this._files);
         if (this._comment) {
             builder.AddSwitchWithValue("comment", this.getComment(), false);
         }

--- a/src/tfvc/commands/checkin.ts
+++ b/src/tfvc/commands/checkin.ts
@@ -87,8 +87,10 @@ export class Checkin implements ITfvcCommand<string> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        const builder: ArgumentBuilder = new ArgumentBuilder("checkin", this._serverContext, true /* skipCollectionOption */)
-            .AddAll(this._files);
+        const builder: ArgumentBuilder = new ArgumentBuilder("checkin", this._serverContext, true /* skipCollectionOption */, true /* isExe */);
+        builder.AddSwitch("noprompt");
+        builder.RemoveSwitch("prompt");
+        builder.AddAll(this._files);
         if (this._comment) {
             builder.AddSwitchWithValue("comment", this.getComment(), false);
         }

--- a/src/tfvc/commands/delete.ts
+++ b/src/tfvc/commands/delete.ts
@@ -80,7 +80,7 @@ export class Delete implements ITfvcCommand<string[]> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        return new ArgumentBuilder("delete", this._serverContext, true /* skipCollectionOption */)
+        return new ArgumentBuilder("delete", this._serverContext, true /* skipCollectionOption */, true /* isExe */)
             .AddAll(this._itemPaths);
     }
 

--- a/src/tfvc/commands/findconflicts.ts
+++ b/src/tfvc/commands/findconflicts.ts
@@ -102,7 +102,7 @@ export class FindConflicts implements ITfvcCommand<IConflict[]> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        const builder: ArgumentBuilder = new ArgumentBuilder("resolve", this._serverContext, true /* skipCollectionOption */)
+        const builder: ArgumentBuilder = new ArgumentBuilder("resolve", this._serverContext, true /* skipCollectionOption */, true /* isExe */)
             .Add(this._itemPath)
             .AddSwitch("recursive")
             .AddSwitch("preview");

--- a/src/tfvc/commands/getfilecontent.ts
+++ b/src/tfvc/commands/getfilecontent.ts
@@ -63,7 +63,7 @@ export class GetFileContent implements ITfvcCommand<string> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        const builder: ArgumentBuilder = new ArgumentBuilder("view", this._serverContext)
+        const builder: ArgumentBuilder = new ArgumentBuilder("view", this._serverContext, false /* skipCollectionOption */, true /* isExe */)
             .Add(this._localPath);
         if (this._versionSpec) {
             builder.AddSwitchWithValue("version", this._versionSpec, false);

--- a/src/tfvc/commands/rename.ts
+++ b/src/tfvc/commands/rename.ts
@@ -76,7 +76,7 @@ export class Rename implements ITfvcCommand<string> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        return new ArgumentBuilder("rename", this._serverContext, true /* skipCollectionOption */)
+        return new ArgumentBuilder("rename", this._serverContext, true /* skipCollectionOption */, true /* isExe */)
             .Add(this._sourcePath)
             .Add(this._destinationPath);
     }

--- a/src/tfvc/commands/resolveconflicts.ts
+++ b/src/tfvc/commands/resolveconflicts.ts
@@ -69,7 +69,7 @@ export class ResolveConflicts implements ITfvcCommand<IConflict[]> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        const builder: ArgumentBuilder = new ArgumentBuilder("resolve", this._serverContext, true /* skipCollectionOption */)
+        const builder: ArgumentBuilder = new ArgumentBuilder("resolve", this._serverContext, true /* skipCollectionOption */, true /* isExe */)
             .AddAll(this._itemPaths)
             .AddSwitchWithValue("auto", AutoResolveType[this._autoResolveType], false);
         return builder;

--- a/src/tfvc/commands/status.ts
+++ b/src/tfvc/commands/status.ts
@@ -88,7 +88,7 @@ export class Status implements ITfvcCommand<IPendingChange[]> {
 
     public GetExeArguments(): IArgumentProvider {
         //return this.GetArguments();
-        const builder: ArgumentBuilder = new ArgumentBuilder("status", this._serverContext)
+        const builder: ArgumentBuilder = new ArgumentBuilder("status", this._serverContext, false /* skipCollectionOption */, true /* isExe */)
             .AddSwitchWithValue("format", "detailed", false)
             .AddSwitch("recursive");
 

--- a/src/tfvc/commands/sync.ts
+++ b/src/tfvc/commands/sync.ts
@@ -92,7 +92,7 @@ export class Sync implements ITfvcCommand<ISyncResults> {
     }
 
     public GetExeArguments(): IArgumentProvider {
-        const builder: ArgumentBuilder = new ArgumentBuilder("get", this._serverContext, true /* skipCollectionOption */)
+        const builder: ArgumentBuilder = new ArgumentBuilder("get", this._serverContext, true /* skipCollectionOption */, true /* isExe */)
             .AddSwitch("nosummary")
             .AddAll(this._itemPaths);
 

--- a/src/tfvc/tfvcrepository.ts
+++ b/src/tfvc/tfvcrepository.ts
@@ -52,8 +52,6 @@ export class TfvcRepository {
         // provides English strings back to us to parse.
         this._env.TF_NOTELEMETRY = "TRUE";
         this._env.TF_ADDITIONAL_JAVA_ARGS = "-Duser.country=US -Duser.language=en";
-
-//        this._env.ATTACH_DEBUGGER = "1";
     }
 
     public get TfvcLocation(): string {

--- a/src/tfvc/tfvcrepository.ts
+++ b/src/tfvc/tfvcrepository.ts
@@ -52,6 +52,8 @@ export class TfvcRepository {
         // provides English strings back to us to parse.
         this._env.TF_NOTELEMETRY = "TRUE";
         this._env.TF_ADDITIONAL_JAVA_ARGS = "-Duser.country=US -Duser.language=en";
+
+//        this._env.ATTACH_DEBUGGER = "1";
     }
 
     public get TfvcLocation(): string {

--- a/test/tfvc/commands/add.test.ts
+++ b/test/tfvc/commands/add.test.ts
@@ -84,7 +84,7 @@ describe("Tfvc-AddCommand", function() {
         const localPaths: string[] = ["/usr/alias/repos/Tfvc.L2VSCodeExtension.RC/README.md"];
         const cmd: Add = new Add(undefined, localPaths);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "add -noprompt " + localPaths[0]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "add -prompt " + localPaths[0]);
     });
 
     it("should verify arguments with context", function() {
@@ -98,7 +98,7 @@ describe("Tfvc-AddCommand", function() {
         const localPaths: string[] = ["/usr/alias/repos/Tfvc.L2VSCodeExtension.RC/README.md"];
         const cmd: Add = new Add(context, localPaths);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "add -noprompt ******** " + localPaths[0]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "add -prompt " + localPaths[0]);
     });
 
     it("should verify parse output - no files to add", async function() {

--- a/test/tfvc/commands/checkin.test.ts
+++ b/test/tfvc/commands/checkin.test.ts
@@ -92,7 +92,7 @@ describe("Tfvc-CheckinCommand", function() {
         const files: string[] = ["/path/to/workspace/file.txt"];
         const cmd: Checkin = new Checkin(context, files);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "checkin -noprompt ******** " + files[0]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "checkin -noprompt " + files[0]);
     });
 
     it("should verify arguments with workitems", function() {
@@ -107,7 +107,7 @@ describe("Tfvc-CheckinCommand", function() {
         const cmd: Checkin = new Checkin(context, files, undefined, [1, 2, 3]);
 
         //Note that no associate option should be here (tf.exe doesn't support it)
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "checkin -noprompt ******** " + files[0]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "checkin -noprompt " + files[0]);
     });
 
     it("should verify arguments with comment", function() {
@@ -121,7 +121,7 @@ describe("Tfvc-CheckinCommand", function() {
         const files: string[] = ["/path/to/workspace/file.txt"];
         const cmd: Checkin = new Checkin(context, files, "a comment\nthat has\r\nmultiple lines");
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "checkin -noprompt ******** " + files[0] + " -comment:a comment that has multiple lines");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "checkin -noprompt " + files[0] + " -comment:a comment that has multiple lines");
     });
 
     it("should verify arguments with all params", function() {
@@ -136,7 +136,7 @@ describe("Tfvc-CheckinCommand", function() {
         const cmd: Checkin = new Checkin(context, files, "a comment", [1, 2, 3]);
 
         //Note that no associate option should be here (tf.exe doesn't support it)
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "checkin -noprompt ******** " + files[0] + " -comment:a comment");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "checkin -noprompt " + files[0] + " -comment:a comment");
     });
 
     it("should verify parse output - no output", async function() {

--- a/test/tfvc/commands/delete.test.ts
+++ b/test/tfvc/commands/delete.test.ts
@@ -83,7 +83,7 @@ describe("Tfvc-DeleteCommand", function() {
         const localPaths: string[] = ["/usr/alias/repos/Tfvc.L2VSCodeExtension.RC/README.md"];
         const cmd: Delete = new Delete(undefined, localPaths);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "delete -noprompt " + localPaths[0]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "delete -prompt " + localPaths[0]);
     });
 
     it("should verify arguments with context", function() {
@@ -97,7 +97,7 @@ describe("Tfvc-DeleteCommand", function() {
         const localPaths: string[] = ["/usr/alias/repos/Tfvc.L2VSCodeExtension.RC/README.md"];
         const cmd: Delete = new Delete(context, localPaths);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "delete -noprompt ******** " + localPaths[0]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "delete -prompt " + localPaths[0]);
     });
 
     it("should verify parse output - single file - no errors", async function() {

--- a/test/tfvc/commands/findconflicts.test.ts
+++ b/test/tfvc/commands/findconflicts.test.ts
@@ -79,7 +79,7 @@ describe("Tfvc-FindConflictsCommand", function() {
         const localPath: string = "/usr/alias/repo1";
         const cmd: FindConflicts = new FindConflicts(undefined, localPath);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "resolve -noprompt " + localPath + " -recursive -preview");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "resolve -prompt " + localPath + " -recursive -preview");
     });
 
     it("should verify arguments with context", function() {
@@ -93,7 +93,7 @@ describe("Tfvc-FindConflictsCommand", function() {
         const localPath: string = "/usr/alias/repo1";
         const cmd: FindConflicts = new FindConflicts(context, localPath);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "resolve -noprompt ******** " + localPath + " -recursive -preview");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "resolve -prompt " + localPath + " -recursive -preview");
     });
 
     it("should verify parse output - no output", async function() {

--- a/test/tfvc/commands/getfilecontent.test.ts
+++ b/test/tfvc/commands/getfilecontent.test.ts
@@ -104,28 +104,28 @@ describe("Tfvc-GetFileContentCommand", function() {
         const localPath: string = "/usr/alias/repos/Tfvc.L2VSCodeExtension.RC/README.md";
         const cmd: GetFileContent = new GetFileContent(undefined, localPath);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "view -noprompt " + localPath);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "view -prompt " + localPath);
     });
 
     it("should verify GetExeArguments with context", function() {
         const localPath: string = "/usr/alias/repos/Tfvc.L2VSCodeExtension.RC/README.md";
         const cmd: GetFileContent = new GetFileContent(context, localPath);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "view -noprompt -collection:" + collectionUrl + " ******** " + localPath);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "view -prompt -collection:" + collectionUrl + " " + localPath);
     });
 
     it("should verify GetExeArguments + versionSpec", function() {
         const localPath: string = "/usr/alias/repos/Tfvc.L2VSCodeExtension.RC/README.md";
         const cmd: GetFileContent = new GetFileContent(undefined, localPath, "42");
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "view -noprompt " + localPath + " -version:42");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "view -prompt " + localPath + " -version:42");
     });
 
     it("should verify GetExeArguments + versionSpec with context", function() {
         const localPath: string = "/usr/alias/repos/Tfvc.L2VSCodeExtension.RC/README.md";
         const cmd: GetFileContent = new GetFileContent(context, localPath, "42");
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "view -noprompt -collection:" + collectionUrl + " ******** " + localPath + " -version:42");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "view -prompt -collection:" + collectionUrl + " " + localPath + " -version:42");
     });
 
     it("should verify parse output - single file - no errors", async function() {

--- a/test/tfvc/commands/rename.test.ts
+++ b/test/tfvc/commands/rename.test.ts
@@ -102,7 +102,7 @@ describe("Tfvc-RenameCommand", function() {
 
         const cmd: Rename = new Rename(context, sourcePath, destinationPath);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "rename -noprompt ******** " + sourcePath + " " + destinationPath);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "rename -prompt " + sourcePath + " " + destinationPath);
     });
 
     it("should verify parse output - no output", async function() {

--- a/test/tfvc/commands/resolveconflicts.test.ts
+++ b/test/tfvc/commands/resolveconflicts.test.ts
@@ -93,21 +93,21 @@ describe("Tfvc-ResolveConflictsCommand", function() {
         const localPaths: string[] = ["/usr/alias/repo1/file.txt"];
         const cmd: ResolveConflicts = new ResolveConflicts(undefined, localPaths, AutoResolveType.KeepYours);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "resolve -noprompt " + localPaths[0] + " -auto:KeepYours");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "resolve -prompt " + localPaths[0] + " -auto:KeepYours");
     });
 
     it("should verify GetExeArguments with context", function() {
         const localPaths: string[] = ["/usr/alias/repo1/file.txt"];
         const cmd: ResolveConflicts = new ResolveConflicts(context, localPaths, AutoResolveType.KeepYours);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "resolve -noprompt ******** " + localPaths[0] + " -auto:KeepYours");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "resolve -prompt " + localPaths[0] + " -auto:KeepYours");
     });
 
     it("should verify GetExeArguments with TakeTheirs", function() {
         const localPaths: string[] = ["/usr/alias/repo1/file.txt"];
         const cmd: ResolveConflicts = new ResolveConflicts(context, localPaths, AutoResolveType.TakeTheirs);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "resolve -noprompt ******** " + localPaths[0] + " -auto:TakeTheirs");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "resolve -prompt " + localPaths[0] + " -auto:TakeTheirs");
     });
 
     it("should verify parse output - no output", async function() {

--- a/test/tfvc/commands/status.test.ts
+++ b/test/tfvc/commands/status.test.ts
@@ -82,7 +82,7 @@ describe("Tfvc-StatusCommand", function() {
         const localPaths: string[] = ["/path/to/workspace"];
         const cmd: Status = new Status(undefined, true, localPaths);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "status -noprompt -format:detailed -recursive " + localPaths[0]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "status -prompt -format:detailed -recursive " + localPaths[0]);
     });
 
     it("should verify arguments - no paths", function() {
@@ -94,7 +94,7 @@ describe("Tfvc-StatusCommand", function() {
     it("should verify Exe arguments - no paths", function() {
         const cmd: Status = new Status(undefined, true);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "status -noprompt -format:detailed -recursive");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "status -prompt -format:detailed -recursive");
     });
 
     it("should verify arguments - multiple paths", function() {
@@ -108,7 +108,7 @@ describe("Tfvc-StatusCommand", function() {
         const localPaths: string[] = ["/path/to/workspace", "/path/to/workspace2"];
         const cmd: Status = new Status(undefined, true, localPaths);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "status -noprompt -format:detailed -recursive " + localPaths[0] + " " + localPaths[1]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "status -prompt -format:detailed -recursive " + localPaths[0] + " " + localPaths[1]);
     });
 
     it("should verify arguments with context", function() {
@@ -122,7 +122,7 @@ describe("Tfvc-StatusCommand", function() {
         const localPaths: string[] = ["/path/to/workspace"];
         const cmd: Status = new Status(context, true, localPaths);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "status -noprompt -collection:" + collectionUrl + " ******** -format:detailed -recursive " + localPaths[0]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "status -prompt -collection:" + collectionUrl + " -format:detailed -recursive " + localPaths[0]);
     });
 
     it("should verify parse output - no output", async function() {

--- a/test/tfvc/commands/sync.test.ts
+++ b/test/tfvc/commands/sync.test.ts
@@ -93,21 +93,21 @@ describe("Tfvc-SyncCommand", function() {
         const localPaths: string[] = ["/usr/alias/repo1"];
         const cmd: Sync = new Sync(undefined, localPaths, false);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "get -noprompt -nosummary " + localPaths[0]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "get -prompt -nosummary " + localPaths[0]);
     });
 
     it("should verify getExeArguments with context", function() {
         const localPaths: string[] = ["/usr/alias/repo1"];
         const cmd: Sync = new Sync(context, localPaths, false);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "get -noprompt ******** -nosummary " + localPaths[0]);
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "get -prompt -nosummary " + localPaths[0]);
     });
 
     it("should verify getExeArguments with context and recursive", function() {
         const localPaths: string[] = ["/usr/alias/repo1"];
         const cmd: Sync = new Sync(context, localPaths, true);
 
-        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "get -noprompt ******** -nosummary " + localPaths[0] + " -recursive");
+        assert.equal(cmd.GetExeArguments().GetArgumentsForDisplay(), "get -prompt -nosummary " + localPaths[0] + " -recursive");
     });
 
     it("should verify parse output - no output", async function() {


### PR DESCRIPTION
The previous code handled the TEE CLC case, and often handled repos with TF.exe as well, but that part was not reliable.  This change makes it so it will prompt for credentials if needed instead of failing.