### PR TITLE
Update Create Pull Request URL

### DIFF
--- a/src/services/gitvc.ts
+++ b/src/services/gitvc.ts
@@ -65,7 +65,7 @@ export class GitVcService {
     //Today, simply craft a url to the create pull request web page
     //https://account.visualstudio.com/DefaultCollection/project/_git/VSCode.Health/pullrequestscreate&sourceRef=master
     public static GetCreatePullRequestUrl(remoteUrl: string, currentBranch: string): string {
-        let pullRequestCreateUrl = UrlBuilder.Join(remoteUrl, "pullrequestcreate");
+        const pullRequestCreateUrl = UrlBuilder.Join(remoteUrl, "pullrequestcreate");
         const branch: string = encodeURIComponent(currentBranch);
         return UrlBuilder.AddQueryParams(pullRequestCreateUrl, `sourceRef=${branch}`);
     }

--- a/src/services/gitvc.ts
+++ b/src/services/gitvc.ts
@@ -63,10 +63,11 @@ export class GitVcService {
     }
 
     //Today, simply craft a url to the create pull request web page
-    //https://account.visualstudio.com/DefaultCollection/project/_git/VSCode.Health/pullrequests#_a=createnew&sourceRef=master
+    //https://account.visualstudio.com/DefaultCollection/project/_git/VSCode.Health/pullrequestscreate&sourceRef=master
     public static GetCreatePullRequestUrl(remoteUrl: string, currentBranch: string): string {
+        let pullRequestCreateUrl = UrlBuilder.Join(remoteUrl, "pullrequestcreate");
         const branch: string = encodeURIComponent(currentBranch);
-        return UrlBuilder.AddHashes(GitVcService.GetPullRequestsUrl(remoteUrl), `_a=createnew`, `sourceRef=${branch}`);
+        return UrlBuilder.AddQueryParams(pullRequestCreateUrl, `sourceRef=${branch}`);
     }
 
     //Construct the url to the view pull request (discussion view)

--- a/test/services/gitvc.test.ts
+++ b/test/services/gitvc.test.ts
@@ -18,8 +18,9 @@ describe("GitVcService", function() {
     it("should verify GetCreatePullRequestUrl", function() {
         const url: string = "https://account.visualstudio.com/DefaultCollection/project";
         const branch: string = "branch";
+        const createUrl = GitVcService.GetCreatePullRequestUrl(url, branch);
 
-        assert.equal(GitVcService.GetCreatePullRequestUrl(url, branch), url + "/pullrequests#_a=createnew&sourceRef=" + branch);
+        assert.equal(createUrl, url + "/pullrequestcreate?sourceRef=" + branch);
     });
 
     it("should verify GetFileBlameUrl", function() {


### PR DESCRIPTION
Currently, `Team: Create Pull Request` performs a few redirects before landing on a page where the user has to manually input the compare branch.  This issue is caused by a stale URL generation.

This PR aims to fix the issue, updating the generated URL from:

from: `https://account.visualstudio.com/DefaultCollection/project/_git/VSCode.Health/pullrequests#_a=createnew&sourceRef=master`
to: `https://account.visualstudio.com/DefaultCollection/project/_git/VSCode.Health/pullrequestscreate&sourceRef=master`

both `gulp` and `gulp test` are successful in my fork.
