### PR TITLE
Support clone URLs generate by Azure DevOps UI

### DIFF
--- a/src/helpers/repoutils.ts
+++ b/src/helpers/repoutils.ts
@@ -25,7 +25,7 @@ import * as url from "url";
 //that a url is NOT either a TFS or Team Services repository.  So it is up to the caller to only
 //instantiate this class if we know we should have either a TFS or Team Services repository.
 export class RepoUtils {
-    private static sshV3 = new RegExp("git@(?:vs-)?ssh\.(.+):v3\/(.+)\/(.+)\/(.+)");
+    private static sshV3 = new RegExp(".+@(?:vs-)?ssh\.(.+):v3\/(.+)\/(.+)\/(.+)");
 
     //Checks a handful of heuristics to see if the url provided is a TFS or VSTS repo
     public static IsTeamFoundationGitRepo(url: string): boolean {


### PR DESCRIPTION
The SSH URLs generated by the Azure DevOps UI do not necessarily start with `git@`. This PR will allow the username to be any non-empty string.