### PR TITLE
Fixing NTLM vs. PAT and NO_PROXY behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "1.142.0",
+  "version": "1.149.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -115,6 +115,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -126,6 +127,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3947,7 +3949,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lowercase-keys": {
       "version": "1.0.1",

--- a/src/clients/httpclient.ts
+++ b/src/clients/httpclient.ts
@@ -64,7 +64,7 @@ export class HttpClient {
         //options.headers["Accept"] = contentType;
         options.headers["User-Agent"] = this.userAgent;
 
-        var useProxy = proxyUrl && proxyUrl.hostname;
+        var useProxy = proxyUrl && proxyUrl.hostname && process.env.NO_PROXY.split(',').filter(function(u){return (new RegExp(u+'$')).test(parsedUrl.hostname);}).length == 0;
         if (useProxy) {
             var agentOptions: tunnel.TunnelOptions = {
                 maxSockets: http.globalAgent.maxSockets,

--- a/src/info/extensionrequesthandler.ts
+++ b/src/info/extensionrequesthandler.ts
@@ -6,7 +6,6 @@
 
 import { IHttpResponse, IRequestHandler } from "vso-node-api/interfaces/common/VsoBaseInterfaces";
 import { getBasicHandler } from "vso-node-api/WebApi";
-import { getNtlmHandler } from "vso-node-api/WebApi";
 import { Constants } from "../helpers/constants";
 import { UserAgentProvider } from "../helpers/useragentprovider";
 
@@ -22,13 +21,13 @@ export class ExtensionRequestHandler implements IRequestHandler {
     constructor(username: string, password?: string, domain?: string, workstation?: string);
 
     constructor(username: string, password?: string, domain?: string, workstation?: string) {
-        if (username !== undefined && password !== undefined) {
-            // NTLM (we don't support Basic auth)
+        if (username && password) {
+            // we'll use basic (we don't support Basic auth, but it must be used for PAT)
             this._username = username;
             this._password = password;
             this._domain = domain;
             this._workstation = workstation;
-            this._credentialHandler = getNtlmHandler(this._username, this._password, this._domain, this._workstation);
+            this._credentialHandler = getBasicHandler(this._username, this._password);
         } else {
             // Personal Access Token
             this._username = Constants.OAuth;

--- a/src/tfvc/commands/argumentbuilder.ts
+++ b/src/tfvc/commands/argumentbuilder.ts
@@ -27,9 +27,7 @@ export class ArgumentBuilder implements IArgumentProvider {
                 //TODO decode URI since CLC does not expect encoded collection urls
                 this.AddSwitchWithValue("collection", serverContext.RepoInfo.CollectionUrl, false);
             }
-            if (serverContext.CredentialInfo) {
-                this.AddSwitchWithValue("login", (serverContext.CredentialInfo.Domain ? serverContext.CredentialInfo.Domain + "\\" : "") + serverContext.CredentialInfo.Username + "," + serverContext.CredentialInfo.Password, true);
-            }
+            // tf.exe doesn't need to have login parameter if it's a local repository previously created by Visual Studio
         }
     }
 


### PR DESCRIPTION
I’m proposing quick patches to handle the environment variable NO_PROXY so proxy won’t be used for local addresses (fixing the behavior of loop request to internal network).
Also fixing the behavior of always using NTLM for local resources, when the destination only allows PAT (personal access tokens) or Kerberos, which is too complex to handle as is now on NodeJS.
Fixes microsoft/azure-repos-vscode#274